### PR TITLE
auth++ dual-issuer allowlist, fail closed on bad config

### DIFF
--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -14,9 +14,9 @@ test("normalizes Cloudflare Access issuer URLs", () => {
   assert.equal(normalizeAccessIssuer(""), null);
 });
 
-test("falls back to JWT issuer when the configured issuer is malformed", () => {
+test("rejects the JWT issuer when the configured issuer is malformed", () => {
   const token = unsignedJwt({ iss: "https://support-chat.cloudflareaccess.com", aud: ["aud"] });
-  assert.equal(resolveAccessIssuerForTest(token, "not a url"), "https://support-chat.cloudflareaccess.com");
+  assert.equal(resolveAccessIssuerForTest(token, "not a url"), null);
 });
 
 test("configured issuer wins when valid", () => {
@@ -24,6 +24,18 @@ test("configured issuer wins when valid", () => {
   assert.equal(resolveAccessIssuerForTest(token, "https://support-chat.cloudflareaccess.com/"), "https://support-chat.cloudflareaccess.com");
 });
 
+test("selects a token issuer from the configured migration allowlist", () => {
+  const oldIssuer = "https://support-chat.cloudflareaccess.com";
+  const newIssuer = "https://ax.cloudflareaccess.com";
+  const configured = `${oldIssuer},${newIssuer}`;
+
+  assert.equal(resolveAccessIssuerForTest(unsignedJwt({ iss: oldIssuer }), configured), oldIssuer);
+  assert.equal(resolveAccessIssuerForTest(unsignedJwt({ iss: newIssuer }), configured), newIssuer);
+  assert.equal(
+    resolveAccessIssuerForTest(unsignedJwt({ iss: "https://evil.example.com" }), configured),
+    null,
+  );
+});
 
 test("dev bypass works for local loopback browser navigation", async () => {
   const identity = await verifyAccessRequest(new Request("http://localhost/api/health"), {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -20,7 +20,7 @@ export interface AccessIdentity {
 
 interface AuthEnv {
   CF_ACCESS_AUD: string;     // Application Audience tag from Zero Trust dashboard
-  CF_ACCESS_ISS: string;     // Team domain, e.g. https://<team>.example.com
+  CF_ACCESS_ISS: string;     // Allowed issuers, comma-separated during a domain migration
   ENVIRONMENT?: string;      // "dev" may bypass verification only for local runtimes
   DEV_USER_EMAIL?: string;
   DEV_USER_GROUPS?: string;  // comma-separated
@@ -56,12 +56,20 @@ function unsafeJwtPayload(token: string): Record<string, unknown> | null {
 }
 
 export function resolveAccessIssuerForTest(token: string, configuredIssuer: unknown) {
-  const configured = normalizeAccessIssuer(configuredIssuer);
-  if (configured) return configured;
-  // Fallback only chooses the JWKS origin. jwtVerify still validates the token
-  // signature and the configured audience below. Without this, a malformed
-  // deploy var breaks every protected route with jose's opaque "Invalid URL".
-  return normalizeAccessIssuer(unsafeJwtPayload(token)?.iss);
+  const configured =
+    typeof configuredIssuer === "string"
+      ? configuredIssuer
+          .split(",")
+          .map(normalizeAccessIssuer)
+          .filter((issuer): issuer is string => issuer !== null)
+      : [];
+  if (configured.length === 0) return null;
+  if (configured.length === 1) return configured[0];
+  if (configured.length > 1) {
+    const tokenIssuer = normalizeAccessIssuer(unsafeJwtPayload(token)?.iss);
+    return tokenIssuer && configured.includes(tokenIssuer) ? tokenIssuer : null;
+  }
+  return null;
 }
 
 function getJWKS(iss: string) {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -15,7 +15,7 @@
 // Required at-deploy vars (override below or via `wrangler deploy --var`):
 //   - CLOUDFLARE_ACCOUNT_ID # your Cloudflare account id
 //   - CF_ACCESS_AUD         # Access app AUD if you front this with Access
-//   - CF_ACCESS_ISS         # Access team domain, e.g. https://<team>.example.com
+//   - CF_ACCESS_ISS         # Access issuer(s), comma-separated during a domain migration
 //   - BRIDGE_BASE_URL       # public origin of this deploy
 //
 // MODELS:


### PR DESCRIPTION
two related access-auth changes:

## security fix
when `CF_ACCESS_ISS` is empty or malformed, the verifier previously fell back to the **unsigned** jwt's `iss` to pick the jwks origin. an attacker could host their own jwks, sign a token with the expected aud, and choose arbitrary identity claims. now the verifier only trusts an explicitly-configured issuer and fails closed otherwise.

## dual-issuer migration support
`CF_ACCESS_ISS` accepts a comma-separated allowlist. the verifier picks the token's `iss` only if it's in the list, then `jwtVerify` checks signature + issuer + aud. this enables a zero-downtime cloudflare access team-domain rename (both old + new issuers trusted during cutover, old one dropped after soak).

## test
`npm run test:auth` (8 tests) + `tsc --noEmit` pass. the malformed-config test now asserts fail-closed (null) instead of the old fallback.