### PR TITLE
chore: genericize internal identifiers in test fixtures

### DIFF
--- a/proof/svelte/streaming-turn-fsm.test.ts
+++ b/proof/svelte/streaming-turn-fsm.test.ts
@@ -22,7 +22,7 @@ function activeState(requestId = "r1"): StreamingTurnState {
   return transition(idleStreamingTurnState, { type: "submit", requestId });
 }
 
-test("CFSA-651 keeps pre-text progress eligible through reasoning and step-only gaps until text", () => {
+test("keeps pre-text progress eligible through reasoning and step-only gaps until text", () => {
   let state = activeState("r1");
   for (const chunkType of ["start", "start-step", "reasoning-delta", "finish-step", "tool-input-available"]) {
     state = transition(state, frame("r1", chunkType));

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -15,18 +15,18 @@ test("normalizes Cloudflare Access issuer URLs", () => {
 });
 
 test("rejects the JWT issuer when the configured issuer is malformed", () => {
-  const token = unsignedJwt({ iss: "https://support-chat.cloudflareaccess.com", aud: ["aud"] });
+  const token = unsignedJwt({ iss: "https://old-team.cloudflareaccess.com", aud: ["aud"] });
   assert.equal(resolveAccessIssuerForTest(token, "not a url"), null);
 });
 
 test("configured issuer wins when valid", () => {
   const token = unsignedJwt({ iss: "https://evil.example.com", aud: ["aud"] });
-  assert.equal(resolveAccessIssuerForTest(token, "https://support-chat.cloudflareaccess.com/"), "https://support-chat.cloudflareaccess.com");
+  assert.equal(resolveAccessIssuerForTest(token, "https://old-team.cloudflareaccess.com/"), "https://old-team.cloudflareaccess.com");
 });
 
 test("selects a token issuer from the configured migration allowlist", () => {
-  const oldIssuer = "https://support-chat.cloudflareaccess.com";
-  const newIssuer = "https://ax.cloudflareaccess.com";
+  const oldIssuer = "https://old-team.cloudflareaccess.com";
+  const newIssuer = "https://new-team.cloudflareaccess.com";
   const configured = `${oldIssuer},${newIssuer}`;
 
   assert.equal(resolveAccessIssuerForTest(unsignedJwt({ iss: oldIssuer }), configured), oldIssuer);


### PR DESCRIPTION
Public-engine hygiene: the SAFE, behavior-neutral subset from the leak review.

- `src/auth.test.ts`: internal Access issuers → generic (`support-chat`→`old-team`, `ax`→`new-team`). Opaque fixtures to the allowlist logic; semantics unchanged.
- `proof/svelte/streaming-turn-fsm.test.ts`: drop the internal Jira key from the test name (title-only string; no code referenced it).

**Deliberately NOT touched:** `src/capability-review.ts` runtime `*.cfdata.org` matchers and their coupled test fixtures — recognizing internal resource URLs IS the feature; genericizing breaks parsing. Those hostnames are inherently public in the matcher.

Tests: auth.test.ts 8/8, streaming-turn-fsm 13/13, `tsc` clean.