### PR TITLE
fix(transcript): merge Think replay into D1 restore instead of clearing it (P1)

### DIFF
--- a/proof/svelte/Chat.svelte
+++ b/proof/svelte/Chat.svelte
@@ -1572,7 +1572,13 @@
     // Merge Think's replay into whatever the D1 eager restore already rendered.
     // Think wins on id collision (authoritative), D1-only messages survive. When
     // Think replayed nothing, this preserves the D1 transcript unchanged.
-    messages = thinkViews.length > 0 ? mergeTranscript(priorMessages, thinkViews) : priorMessages;
+    // keepExistingOnlyIf: retain a D1 message Think omitted ONLY if it is a genuine
+    // turn (real ui id). D1 tool rows are synthetic `d1-<n>` system messages that
+    // Think re-renders as inline assistant parts, so dropping them here avoids
+    // duplicated tool output.
+    messages = thinkViews.length > 0
+      ? mergeTranscript(priorMessages, thinkViews, { keepExistingOnlyIf: (m) => !m.id.startsWith("d1-") })
+      : priorMessages;
     void hydrateHistoryTimestamps();
     void revealResumedHistoryAtBottom();
   }

--- a/proof/svelte/Chat.svelte
+++ b/proof/svelte/Chat.svelte
@@ -13,6 +13,7 @@
   import { parseMyAxDeepLink, type MyAxDeepLink } from "./deep-links";
   import { SessionGenerationGuard, type SessionGeneration } from "./session-generation";
   import { loadCurrentSessionEntries, shouldReportEmptyRestore, type RestoreOutcome } from "./session-history";
+  import { mergeTranscript } from "./transcript-merge";
   import { createReconnectingSocket } from "./reconnecting-socket";
   import { activeTurnIsRestorable, pendingFirstBelongsHere } from "./session-latch";
   import { captureConfig, frameDimensions, frameFilename } from "./webcam-frame";
@@ -1483,7 +1484,15 @@
     const wasResuming = resumingExistingSession;
     thinkMessages = historyMessages || [];
     const existingTimestamps = new Map(messages.map((message) => [message.id, message.timestamp]));
-    messages = [];
+    // Do NOT clear the transcript here. The D1 eager restore already rendered the
+    // durable, complete history; Think's replay is authoritative for content but can
+    // be COMPACTED (fewer messages than the human wrote). Clearing then rebuilding
+    // from Think alone dropped any assistant reply Think omitted (the P1 "replies
+    // lost" race). Instead we build Think's views separately and MERGE: Think wins on
+    // id collision (authoritative content), but D1-only messages are kept. See
+    // transcript-merge.ts. Alignment is by id (D1 meta.uiMessageId === Think id).
+    const priorMessages = messages;
+    const thinkViews: MessageView[] = [];
     if (thinkMessages.length > 0) {
       onboardingHidden = true;
       if (wasResuming) {
@@ -1558,8 +1567,12 @@
         streaming: false,
         pending: false,
       };
-      messages = [...messages, m];
+      thinkViews.push(m);
     }
+    // Merge Think's replay into whatever the D1 eager restore already rendered.
+    // Think wins on id collision (authoritative), D1-only messages survive. When
+    // Think replayed nothing, this preserves the D1 transcript unchanged.
+    messages = thinkViews.length > 0 ? mergeTranscript(priorMessages, thinkViews) : priorMessages;
     void hydrateHistoryTimestamps();
     void revealResumedHistoryAtBottom();
   }

--- a/proof/svelte/transcript-merge.test.ts
+++ b/proof/svelte/transcript-merge.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mergeTranscript } from "./transcript-merge";
+
+const msg = (
+  id: string,
+  role: string,
+  timestamp?: number,
+  extra: Record<string, unknown> = {},
+): { id: string; role: string; timestamp?: number; content?: string; [k: string]: unknown } =>
+  ({ id, role, timestamp, ...extra });
+
+// THE bug: D1 restored an assistant reply; Think's compacted replay omits it.
+test("keeps a D1-only assistant reply that Think's replay omitted", () => {
+  const d1 = [msg("u1", "user", 1), msg("a1", "assistant", 2), msg("u2", "user", 3), msg("a2", "assistant", 4)];
+  const think = [msg("u1", "user", 1), msg("u2", "user", 3), msg("a2", "assistant", 4)]; // a1 compacted away
+  const merged = mergeTranscript(d1, think);
+  assert.deepEqual(merged.map((m) => m.id), ["u1", "a1", "u2", "a2"]);
+  assert.ok(merged.find((m) => m.id === "a1"), "the assistant reply must survive");
+});
+
+test("Think's version wins for a message present in both (authoritative content)", () => {
+  const d1 = [msg("a1", "assistant", 2, { content: "d1 partial" })];
+  const think = [msg("a1", "assistant", 2, { content: "think full" })];
+  const merged = mergeTranscript(d1, think);
+  assert.equal(merged.length, 1);
+  assert.equal(merged[0].content, "think full");
+});
+
+test("empty Think replay keeps the full D1 transcript", () => {
+  const d1 = [msg("u1", "user", 1), msg("a1", "assistant", 2)];
+  const merged = mergeTranscript(d1, []);
+  assert.deepEqual(merged.map((m) => m.id), ["u1", "a1"]);
+});
+
+test("adds Think-only messages not yet in D1", () => {
+  const d1 = [msg("u1", "user", 1)];
+  const think = [msg("u1", "user", 1), msg("a1", "assistant", 2)];
+  const merged = mergeTranscript(d1, think);
+  assert.deepEqual(merged.map((m) => m.id), ["u1", "a1"]);
+});
+
+test("orders by timestamp ascending across both sources", () => {
+  const d1 = [msg("a2", "assistant", 40), msg("a1", "assistant", 20)];
+  const think = [msg("u1", "user", 10), msg("u2", "user", 30)];
+  const merged = mergeTranscript(d1, think);
+  assert.deepEqual(merged.map((m) => m.id), ["u1", "a1", "u2", "a2"]);
+});
+
+test("stable first-seen order for equal/absent timestamps", () => {
+  const d1 = [msg("x", "user"), msg("y", "assistant")];
+  const think = [msg("z", "user")];
+  const merged = mergeTranscript(d1, think);
+  assert.deepEqual(merged.map((m) => m.id), ["x", "y", "z"]);
+});
+
+test("preferIncoming=false keeps existing on collision (defensive option)", () => {
+  const d1 = [msg("a1", "assistant", 2, { content: "keep me" })];
+  const think = [msg("a1", "assistant", 2, { content: "discard" })];
+  const merged = mergeTranscript(d1, think, { preferIncoming: false });
+  assert.equal(merged[0].content, "keep me");
+});
+
+test("no duplicate ids in output when both sides share ids", () => {
+  const d1 = [msg("u1", "user", 1), msg("a1", "assistant", 2)];
+  const think = [msg("u1", "user", 1), msg("a1", "assistant", 2)];
+  const merged = mergeTranscript(d1, think);
+  assert.equal(merged.length, 2);
+  assert.equal(new Set(merged.map((m) => m.id)).size, 2);
+});

--- a/proof/svelte/transcript-merge.test.ts
+++ b/proof/svelte/transcript-merge.test.ts
@@ -61,6 +61,26 @@ test("preferIncoming=false keeps existing on collision (defensive option)", () =
   assert.equal(merged[0].content, "keep me");
 });
 
+test("keepExistingOnlyIf drops D1-only synthetic tool rows but keeps real turns", () => {
+  // D1 restored: a real assistant turn (a1) + a synthetic tool row (d1-9).
+  // Think's replay omits both (compacted) but will re-render the tool inline.
+  const d1 = [msg("u1", "user", 1), msg("a1", "assistant", 2), msg("d1-9", "system", 3)];
+  const think = [msg("u1", "user", 1)];
+  const merged = mergeTranscript(d1, think, { keepExistingOnlyIf: (m) => !m.id.startsWith("d1-") });
+  assert.deepEqual(merged.map((m) => m.id), ["u1", "a1"]);
+  assert.ok(!merged.find((m) => m.id === "d1-9"), "synthetic tool row must be dropped");
+});
+
+test("keepExistingOnlyIf still keeps a d1- row if Think ALSO has that id (collision path)", () => {
+  // Defensive: if the same id appears on both sides, it's not existing-only, so the
+  // predicate does not apply and the incoming (Think) version is used.
+  const d1 = [msg("d1-9", "system", 3, { content: "d1" })];
+  const think = [msg("d1-9", "assistant", 3, { content: "think" })];
+  const merged = mergeTranscript(d1, think, { keepExistingOnlyIf: (m) => !m.id.startsWith("d1-") });
+  assert.equal(merged.length, 1);
+  assert.equal(merged[0].content, "think");
+});
+
 test("no duplicate ids in output when both sides share ids", () => {
   const d1 = [msg("u1", "user", 1), msg("a1", "assistant", 2)];
   const think = [msg("u1", "user", 1), msg("a1", "assistant", 2)];

--- a/proof/svelte/transcript-merge.ts
+++ b/proof/svelte/transcript-merge.ts
@@ -1,0 +1,74 @@
+// transcript-merge.ts — the fix for the large-thread "assistant replies lost" race.
+//
+// On resume, two transcripts arrive: the durable D1 eager restore (fast, complete)
+// and Think's cf_agent_chat_messages replay (authoritative content, but possibly
+// COMPACTED or still materializing). The old code did `messages = []` then rebuilt
+// from Think alone, so any message D1 had but Think's replay omitted (notably
+// assistant replies on a long/compacted thread) vanished from the view.
+//
+// mergeTranscript merges instead of replacing: Think's version WINS for a message
+// present in both (it's authoritative), but a message present only in the existing
+// (D1) view is KEPT. Alignment is by id — D1 view ids are `meta.uiMessageId || d1-<n>`
+// and Think view ids are `message.id`, and the server sets meta.uiMessageId =
+// message.id, so the same logical message shares an id across both sources.
+
+export type MergeableMessage = {
+  id: string;
+  role: string;
+  timestamp?: number;
+  // Opaque to the merge; carried through untouched.
+  [key: string]: unknown;
+};
+
+export type MergeOptions = {
+  // When true (Think replay), incoming entries override existing on id collision.
+  // The default is what the resume path wants.
+  preferIncoming?: boolean;
+};
+
+/**
+ * Merge two transcript views by id, keeping messages that exist in only one side.
+ *
+ * - id in BOTH: `preferIncoming` (default true) keeps the incoming (Think) version.
+ * - id only in `existing` (D1-only, e.g. an assistant reply Think compacted away): KEPT.
+ * - id only in `incoming`: added.
+ *
+ * Order: by timestamp ascending (chronological), stable for equal/absent timestamps
+ * using first-seen order across [existing, incoming]. This preserves the interleaving
+ * a user expects and never reorders equal-timestamp neighbors nondeterministically.
+ */
+export function mergeTranscript<T extends MergeableMessage>(
+  existing: T[],
+  incoming: T[],
+  options: MergeOptions = {},
+): T[] {
+  const preferIncoming = options.preferIncoming ?? true;
+
+  // First-seen order gives a stable tiebreaker for equal timestamps.
+  const order = new Map<string, number>();
+  let seq = 0;
+  const chosen = new Map<string, T>();
+
+  const consider = (msg: T, incomingSide: boolean) => {
+    if (!order.has(msg.id)) order.set(msg.id, seq++);
+    const prior = chosen.get(msg.id);
+    if (prior === undefined) {
+      chosen.set(msg.id, msg);
+      return;
+    }
+    // Collision: pick per preference. incomingSide === true means `msg` is from `incoming`.
+    if (incomingSide === preferIncoming) chosen.set(msg.id, msg);
+  };
+
+  for (const m of existing) consider(m, false);
+  for (const m of incoming) consider(m, true);
+
+  const merged = [...chosen.values()];
+  merged.sort((a, b) => {
+    const ta = typeof a.timestamp === "number" ? a.timestamp : Number.POSITIVE_INFINITY;
+    const tb = typeof b.timestamp === "number" ? b.timestamp : Number.POSITIVE_INFINITY;
+    if (ta !== tb) return ta - tb;
+    return (order.get(a.id) ?? 0) - (order.get(b.id) ?? 0);
+  });
+  return merged;
+}

--- a/proof/svelte/transcript-merge.ts
+++ b/proof/svelte/transcript-merge.ts
@@ -24,6 +24,14 @@ export type MergeOptions = {
   // When true (Think replay), incoming entries override existing on id collision.
   // The default is what the resume path wants.
   preferIncoming?: boolean;
+  // Predicate deciding whether an EXISTING (D1) message that Think's replay OMITTED
+  // may be retained. Needed because D1 tool rows render as standalone `system`
+  // messages with synthetic `d1-<n>` ids, but Think represents those same tool
+  // calls as INLINE parts of assistant messages — so keeping the D1 tool rows on
+  // top of Think's replay would DUPLICATE them. Only genuine turns that carry a
+  // real ui id (a user/assistant message Think may have compacted away) should be
+  // retained. Defaults to keeping everything (pure-merge semantics for tests).
+  keepExistingOnlyIf?: (msg: MergeableMessage) => boolean;
 };
 
 /**
@@ -43,6 +51,12 @@ export function mergeTranscript<T extends MergeableMessage>(
   options: MergeOptions = {},
 ): T[] {
   const preferIncoming = options.preferIncoming ?? true;
+  const keepExistingOnlyIf = options.keepExistingOnlyIf;
+
+  // A message that exists ONLY in `incoming` is always kept. An existing-only
+  // message is kept unless the caller's predicate rejects it (used to drop D1
+  // tool/synthetic rows that Think re-materializes inline).
+  const incomingIds = new Set(incoming.map((m) => m.id));
 
   // First-seen order gives a stable tiebreaker for equal timestamps.
   const order = new Map<string, number>();
@@ -60,7 +74,10 @@ export function mergeTranscript<T extends MergeableMessage>(
     if (incomingSide === preferIncoming) chosen.set(msg.id, msg);
   };
 
-  for (const m of existing) consider(m, false);
+  for (const m of existing) {
+    if (keepExistingOnlyIf && !incomingIds.has(m.id) && !keepExistingOnlyIf(m)) continue;
+    consider(m, false);
+  }
   for (const m of incoming) consider(m, true);
 
   const merged = [...chosen.values()];


### PR DESCRIPTION
## P1 — large-thread transcript race (assistant replies appear lost)

Opening a long session (resume or push deep-link) could show owner messages but no assistant replies.

**Root cause:** on resume the D1 eager restore renders the full durable transcript, then Think's `cf_agent_chat_messages` replay ran `messages = []` and rebuilt from Think alone. On a long/compacted thread Think replays fewer messages than the human wrote, and `reconcileCompactedHistory` only repairs a user-turn *count* mismatch — so assistant replies present in D1 but omitted by Think's compacted replay were wiped.

**Fix:** `renderThinkHistory` now builds Think's views separately and **merges** into the D1-rendered transcript (`transcript-merge.ts`): Think wins on id collision (authoritative), D1-only genuine turns are kept, and synthetic `d1-*` tool rows are dropped (Think re-renders those inline — avoids duplication). Alignment by id (server sets `meta.uiMessageId = message.id`). Empty Think replay preserves D1 unchanged.

**Tests:** pure `mergeTranscript` unit-tested (10 cases incl. the exact bug + the tool-dup guard). Full check gate green. Client-render only — no server/auth/persistence change.

Stages 2–5 (newest-first bounded page, reconcile off onConnect, index the json_extract dedup, sandbox off first paint) tracked as follow-ups.