### PR TITLE
fix(transcript): P1 large-thread race — merge + newest-first + reconcile-defer + dedup index (S1–S5)

### DIFF
--- a/migrations/0022_conversation_uimsgid_index.sql
+++ b/migrations/0022_conversation_uimsgid_index.sql
@@ -1,25 +1,24 @@
--- P1 transcript-race Stage 4: index the uiMessageId dedup lookup.
+-- P1 transcript-race Stage 4: index the uiMessageId / toolCallId dedup lookups.
 --
 -- appendConversationLog and reconcileAssistantHistory dedup by
 --   WHERE session_id = ? AND owner_email = ? AND role = ? AND json_extract(meta_json,'$.uiMessageId') = ?
--- With no supporting index that is a scan per candidate message. On a long
--- thread reconcile (formerly on every onConnect) this multiplied into the
--- open-path stall. SQLite/D1 support expression indexes, so index the exact
--- json_extract expression alongside the equality-filtered columns.
+-- With no supporting index that is a scan per candidate row.
 --
--- Additive + idempotent. No data change.
-CREATE INDEX IF NOT EXISTS idx_conversation_entries_uimsgid
-    ON conversation_entries(
-        session_id,
-        owner_email,
-        role,
-        json_extract(meta_json, '$.uiMessageId')
-    );
+-- D1 rejects an expression index directly on json_extract() (SQLITE_ERROR 7500:
+-- json_extract is not index-safe there). Instead we add VIRTUAL generated
+-- columns that project the JSON fields, then index those. VIRTUAL (not STORED)
+-- means no table rewrite and no extra row storage — the value is computed on
+-- read, and the index materializes it. Additive + idempotent-friendly.
+ALTER TABLE conversation_entries
+    ADD COLUMN ui_message_id TEXT
+    GENERATED ALWAYS AS (json_extract(meta_json, '$.uiMessageId')) VIRTUAL;
 
--- The toolCallId dedup path (conversation-log.ts) uses the same shape for tools.
+ALTER TABLE conversation_entries
+    ADD COLUMN tool_call_id TEXT
+    GENERATED ALWAYS AS (json_extract(meta_json, '$.toolCallId')) VIRTUAL;
+
+CREATE INDEX IF NOT EXISTS idx_conversation_entries_uimsgid
+    ON conversation_entries(session_id, owner_email, role, ui_message_id);
+
 CREATE INDEX IF NOT EXISTS idx_conversation_entries_toolcallid
-    ON conversation_entries(
-        session_id,
-        owner_email,
-        json_extract(meta_json, '$.toolCallId')
-    );
+    ON conversation_entries(session_id, owner_email, tool_call_id);

--- a/migrations/0022_conversation_uimsgid_index.sql
+++ b/migrations/0022_conversation_uimsgid_index.sql
@@ -1,21 +1,29 @@
 -- P1 transcript-race Stage 4: index the uiMessageId / toolCallId dedup lookups.
 --
 -- appendConversationLog and reconcileAssistantHistory dedup by
---   WHERE session_id = ? AND owner_email = ? AND role = ? AND json_extract(meta_json,'$.uiMessageId') = ?
+--   WHERE session_id = ? AND owner_email = ? AND role = ? AND <uiMessageId> = ?
 -- With no supporting index that is a scan per candidate row.
 --
--- D1 rejects an expression index directly on json_extract() (SQLITE_ERROR 7500:
--- json_extract is not index-safe there). Instead we add VIRTUAL generated
--- columns that project the JSON fields, then index those. VIRTUAL (not STORED)
--- means no table rewrite and no extra row storage — the value is computed on
--- read, and the index materializes it. Additive + idempotent-friendly.
+-- Two D1 gotchas this migration works around (both hit on the real remote DB):
+--   1. D1 rejects an expression index directly on json_extract() (SQLITE_ERROR
+--      7500). So we project the field into a VIRTUAL generated column and index
+--      that instead.
+--   2. Some existing rows have NON-JSON meta_json (34 on prod at migration time),
+--      and json_extract() over invalid JSON throws 7500 when the index is built.
+--      Guard with json_valid() so bad rows yield NULL instead of aborting.
+-- VIRTUAL (not STORED) = no table rewrite, value computed on read + materialized
+-- by the index. Additive.
 ALTER TABLE conversation_entries
     ADD COLUMN ui_message_id TEXT
-    GENERATED ALWAYS AS (json_extract(meta_json, '$.uiMessageId')) VIRTUAL;
+    GENERATED ALWAYS AS (
+        CASE WHEN json_valid(meta_json) THEN json_extract(meta_json, '$.uiMessageId') END
+    ) VIRTUAL;
 
 ALTER TABLE conversation_entries
     ADD COLUMN tool_call_id TEXT
-    GENERATED ALWAYS AS (json_extract(meta_json, '$.toolCallId')) VIRTUAL;
+    GENERATED ALWAYS AS (
+        CASE WHEN json_valid(meta_json) THEN json_extract(meta_json, '$.toolCallId') END
+    ) VIRTUAL;
 
 CREATE INDEX IF NOT EXISTS idx_conversation_entries_uimsgid
     ON conversation_entries(session_id, owner_email, role, ui_message_id);

--- a/migrations/0022_conversation_uimsgid_index.sql
+++ b/migrations/0022_conversation_uimsgid_index.sql
@@ -1,0 +1,25 @@
+-- P1 transcript-race Stage 4: index the uiMessageId dedup lookup.
+--
+-- appendConversationLog and reconcileAssistantHistory dedup by
+--   WHERE session_id = ? AND owner_email = ? AND role = ? AND json_extract(meta_json,'$.uiMessageId') = ?
+-- With no supporting index that is a scan per candidate message. On a long
+-- thread reconcile (formerly on every onConnect) this multiplied into the
+-- open-path stall. SQLite/D1 support expression indexes, so index the exact
+-- json_extract expression alongside the equality-filtered columns.
+--
+-- Additive + idempotent. No data change.
+CREATE INDEX IF NOT EXISTS idx_conversation_entries_uimsgid
+    ON conversation_entries(
+        session_id,
+        owner_email,
+        role,
+        json_extract(meta_json, '$.uiMessageId')
+    );
+
+-- The toolCallId dedup path (conversation-log.ts) uses the same shape for tools.
+CREATE INDEX IF NOT EXISTS idx_conversation_entries_toolcallid
+    ON conversation_entries(
+        session_id,
+        owner_email,
+        json_extract(meta_json, '$.toolCallId')
+    );

--- a/proof/svelte/Chat.svelte
+++ b/proof/svelte/Chat.svelte
@@ -1572,7 +1572,13 @@
     // Merge Think's replay into whatever the D1 eager restore already rendered.
     // Think wins on id collision (authoritative), D1-only messages survive. When
     // Think replayed nothing, this preserves the D1 transcript unchanged.
-    messages = thinkViews.length > 0 ? mergeTranscript(priorMessages, thinkViews) : priorMessages;
+    // keepExistingOnlyIf: retain a D1 message Think omitted ONLY if it is a genuine
+    // turn (real ui id). D1 tool rows are synthetic `d1-<n>` system messages that
+    // Think re-renders as inline assistant parts, so dropping them here avoids
+    // duplicated tool output.
+    messages = thinkViews.length > 0
+      ? mergeTranscript(priorMessages, thinkViews, { keepExistingOnlyIf: (m) => !m.id.startsWith("d1-") })
+      : priorMessages;
     void hydrateHistoryTimestamps();
     void revealResumedHistoryAtBottom();
   }

--- a/proof/svelte/Chat.svelte
+++ b/proof/svelte/Chat.svelte
@@ -1508,7 +1508,13 @@
       const body = await res.json();
       if (!sessionWorkIsCurrent(expected)) return;
       const r = body?.result ?? {};
-      const older: Message[] = (r.entries ?? []).map(d1EntryToMessage);
+      // Drop synthetic d1- tool rows from paged-older history: Think renders tool
+      // calls as inline assistant parts, so a standalone d1- system row would
+      // duplicate an inline tool once the assistant turn is also shown. Keep only
+      // genuine turns (real ui id) that aren't already in the view.
+      const older: Message[] = (r.entries ?? [])
+        .map(d1EntryToMessage)
+        .filter((m: Message) => !m.id.startsWith("d1-"));
       if (older.length) messages = mergeTranscript(older as any, messages as any) as typeof messages;
       olderHistoryCursor = r.hasOlder ? (r.olderCursor ?? "") : "";
     } catch {

--- a/proof/svelte/Chat.svelte
+++ b/proof/svelte/Chat.svelte
@@ -13,6 +13,7 @@
   import { parseMyAxDeepLink, type MyAxDeepLink } from "./deep-links";
   import { SessionGenerationGuard, type SessionGeneration } from "./session-generation";
   import { loadCurrentSessionEntries, shouldReportEmptyRestore, type RestoreOutcome } from "./session-history";
+  import { mergeTranscript } from "./transcript-merge";
   import { createReconnectingSocket } from "./reconnecting-socket";
   import { activeTurnIsRestorable, pendingFirstBelongsHere } from "./session-latch";
   import { captureConfig, frameDimensions, frameFilename } from "./webcam-frame";
@@ -1483,7 +1484,15 @@
     const wasResuming = resumingExistingSession;
     thinkMessages = historyMessages || [];
     const existingTimestamps = new Map(messages.map((message) => [message.id, message.timestamp]));
-    messages = [];
+    // Do NOT clear the transcript here. The D1 eager restore already rendered the
+    // durable, complete history; Think's replay is authoritative for content but can
+    // be COMPACTED (fewer messages than the human wrote). Clearing then rebuilding
+    // from Think alone dropped any assistant reply Think omitted (the P1 "replies
+    // lost" race). Instead we build Think's views separately and MERGE: Think wins on
+    // id collision (authoritative content), but D1-only messages are kept. See
+    // transcript-merge.ts. Alignment is by id (D1 meta.uiMessageId === Think id).
+    const priorMessages = messages;
+    const thinkViews: MessageView[] = [];
     if (thinkMessages.length > 0) {
       onboardingHidden = true;
       if (wasResuming) {
@@ -1558,8 +1567,12 @@
         streaming: false,
         pending: false,
       };
-      messages = [...messages, m];
+      thinkViews.push(m);
     }
+    // Merge Think's replay into whatever the D1 eager restore already rendered.
+    // Think wins on id collision (authoritative), D1-only messages survive. When
+    // Think replayed nothing, this preserves the D1 transcript unchanged.
+    messages = thinkViews.length > 0 ? mergeTranscript(priorMessages, thinkViews) : priorMessages;
     void hydrateHistoryTimestamps();
     void revealResumedHistoryAtBottom();
   }

--- a/proof/svelte/Chat.svelte
+++ b/proof/svelte/Chat.svelte
@@ -599,6 +599,16 @@
   }
   function syncScrollToBottom() {
     scrollToBottomVisible = !isLogPinned();
+    // P1 Stage 2: page older history when the user scrolls near the top. Preserve
+    // the visual position across the prepend so the viewport doesn't jump.
+    if (logEl && logEl.scrollTop < 200 && olderHistoryCursor !== null && olderHistoryCursor !== "" && !loadingOlderHistory) {
+      const prevHeight = logEl.scrollHeight;
+      const prevTop = logEl.scrollTop;
+      void loadOlderHistory().then(async () => {
+        await tick();
+        if (logEl) logEl.scrollTop = prevTop + (logEl.scrollHeight - prevHeight);
+      });
+    }
   }
   function queueScrollToBottom() {
     if (!logEl) return;
@@ -1425,6 +1435,25 @@
     fetchPage: (after) => fetch(`/api/sessions/${encodeURIComponent(expected.sessionId)}/entries?after=${encodeURIComponent(after)}&limit=200`, { credentials: "include" }),
   });
 
+  // P1 Stage 2: cursor for paging OLDER history on scroll-up after the newest
+  // page rendered. null = not yet loaded; "" = no older history remains.
+  let olderHistoryCursor: string | null = null;
+  let loadingOlderHistory = false;
+
+  // Fetch ONE newest-first bounded page (fast first paint). Returns entries in
+  // chronological order plus the cursor to page further back.
+  async function loadNewestEntries(expected: SessionGeneration, limit = 100): Promise<
+    { outcome: "stale" } | { outcome: "current"; entries: any[]; olderCursor: string | null; hasOlder: boolean }
+  > {
+    if (!sessionWorkIsCurrent(expected)) return { outcome: "stale" };
+    const res = await fetch(`/api/sessions/${encodeURIComponent(expected.sessionId)}/entries?order=desc&limit=${limit}`, { credentials: "include" });
+    if (!res.ok || !sessionWorkIsCurrent(expected)) return { outcome: "stale" };
+    const body = await res.json();
+    if (!sessionWorkIsCurrent(expected)) return { outcome: "stale" };
+    const r = body?.result ?? {};
+    return { outcome: "current", entries: r.entries ?? [], olderCursor: r.olderCursor ?? null, hasOlder: !!r.hasOlder };
+  }
+
   async function hydrateHistoryTimestamps() {
     const expected = sessionGeneration.capture();
     if (!expected) return;
@@ -1440,24 +1469,53 @@
     messages = messages.map((message) => ({ ...message, timestamp: timestamps.get(message.id) ?? message.timestamp }));
   }
 
+  function d1EntryToMessage(entry: any): Message {
+    const role = entry.role === "tool" ? "system" : entry.role;
+    const label = entry.role === "tool" ? `[${entry.tool || "tool"}] ` : "";
+    return { id: entry.meta?.uiMessageId || `d1-${entry.id}`, role, content: `${label}${entry.content || ""}`, parts: [{ kind: "text", text: `${label}${entry.content || ""}`, rendered: role === "assistant" ? renderMarkdown(entry.content || "") : undefined }], timestamp: Date.parse(entry.createdAt) || Date.now(), streaming: false };
+  }
+
   async function restoreD1History(expected = sessionGeneration.capture(), quiet = false): Promise<RestoreOutcome> {
     if (!expected || !sessionWorkIsCurrent(expected)) return "stale";
-    const result = await loadSessionEntries(expected, 20);
+    // P1 Stage 2: render ONE newest-first bounded page immediately instead of
+    // draining up to 20 oldest-first 200-row pages before first paint. Older
+    // history pages in on scroll-up via loadOlderHistory.
+    const result = await loadNewestEntries(expected, 100);
     if (result.outcome === "stale") return "stale";
-    const restored: Message[] = [];
-    for (const entry of result.entries) {
-      const role = entry.role === "tool" ? "system" : entry.role;
-      const label = entry.role === "tool" ? `[${entry.tool || "tool"}] ` : "";
-      restored.push({ id: entry.meta?.uiMessageId || `d1-${entry.id}`, role, content: `${label}${entry.content || ""}`, parts: [{ kind: "text", text: `${label}${entry.content || ""}`, rendered: role === "assistant" ? renderMarkdown(entry.content || "") : undefined }], timestamp: Date.parse(entry.createdAt) || Date.now(), streaming: false });
-    }
+    const restored: Message[] = result.entries.map(d1EntryToMessage);
     if (!sessionWorkIsCurrent(expected)) return "stale";
     if (!restored.length) return "empty";
     messages = restored;
+    olderHistoryCursor = result.hasOlder ? (result.olderCursor ?? "") : "";
     onboardingHidden = true;
     // The eager fast-path load is a normal resume, not a recovery — stay quiet.
     // The explicit recovery paths (empty Think replay) still surface the notice.
     if (!quiet) pushSystem("Conversation restored from the durable transcript.");
     return "restored";
+  }
+
+  // P1 Stage 2: page older history on scroll-up. Prepends an older newest-first
+  // page (chronological) ahead of the current transcript, merged by id so a
+  // Think replay that already rendered some of these does not duplicate them.
+  async function loadOlderHistory(): Promise<void> {
+    if (loadingOlderHistory || olderHistoryCursor === null || olderHistoryCursor === "") return;
+    const expected = sessionGeneration.capture();
+    if (!expected) return;
+    loadingOlderHistory = true;
+    try {
+      const res = await fetch(`/api/sessions/${encodeURIComponent(expected.sessionId)}/entries?order=desc&before=${encodeURIComponent(olderHistoryCursor)}&limit=100`, { credentials: "include" });
+      if (!res.ok || !sessionWorkIsCurrent(expected)) return;
+      const body = await res.json();
+      if (!sessionWorkIsCurrent(expected)) return;
+      const r = body?.result ?? {};
+      const older: Message[] = (r.entries ?? []).map(d1EntryToMessage);
+      if (older.length) messages = mergeTranscript(older as any, messages as any) as typeof messages;
+      olderHistoryCursor = r.hasOlder ? (r.olderCursor ?? "") : "";
+    } catch {
+      // leave cursor intact so a later scroll retries
+    } finally {
+      loadingOlderHistory = false;
+    }
   }
 
   // When Think compacts a long session it replays fewer messages than the

--- a/proof/svelte/transcript-merge.test.ts
+++ b/proof/svelte/transcript-merge.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mergeTranscript } from "./transcript-merge";
+
+const msg = (
+  id: string,
+  role: string,
+  timestamp?: number,
+  extra: Record<string, unknown> = {},
+): { id: string; role: string; timestamp?: number; content?: string; [k: string]: unknown } =>
+  ({ id, role, timestamp, ...extra });
+
+// THE bug: D1 restored an assistant reply; Think's compacted replay omits it.
+test("keeps a D1-only assistant reply that Think's replay omitted", () => {
+  const d1 = [msg("u1", "user", 1), msg("a1", "assistant", 2), msg("u2", "user", 3), msg("a2", "assistant", 4)];
+  const think = [msg("u1", "user", 1), msg("u2", "user", 3), msg("a2", "assistant", 4)]; // a1 compacted away
+  const merged = mergeTranscript(d1, think);
+  assert.deepEqual(merged.map((m) => m.id), ["u1", "a1", "u2", "a2"]);
+  assert.ok(merged.find((m) => m.id === "a1"), "the assistant reply must survive");
+});
+
+test("Think's version wins for a message present in both (authoritative content)", () => {
+  const d1 = [msg("a1", "assistant", 2, { content: "d1 partial" })];
+  const think = [msg("a1", "assistant", 2, { content: "think full" })];
+  const merged = mergeTranscript(d1, think);
+  assert.equal(merged.length, 1);
+  assert.equal(merged[0].content, "think full");
+});
+
+test("empty Think replay keeps the full D1 transcript", () => {
+  const d1 = [msg("u1", "user", 1), msg("a1", "assistant", 2)];
+  const merged = mergeTranscript(d1, []);
+  assert.deepEqual(merged.map((m) => m.id), ["u1", "a1"]);
+});
+
+test("adds Think-only messages not yet in D1", () => {
+  const d1 = [msg("u1", "user", 1)];
+  const think = [msg("u1", "user", 1), msg("a1", "assistant", 2)];
+  const merged = mergeTranscript(d1, think);
+  assert.deepEqual(merged.map((m) => m.id), ["u1", "a1"]);
+});
+
+test("orders by timestamp ascending across both sources", () => {
+  const d1 = [msg("a2", "assistant", 40), msg("a1", "assistant", 20)];
+  const think = [msg("u1", "user", 10), msg("u2", "user", 30)];
+  const merged = mergeTranscript(d1, think);
+  assert.deepEqual(merged.map((m) => m.id), ["u1", "a1", "u2", "a2"]);
+});
+
+test("stable first-seen order for equal/absent timestamps", () => {
+  const d1 = [msg("x", "user"), msg("y", "assistant")];
+  const think = [msg("z", "user")];
+  const merged = mergeTranscript(d1, think);
+  assert.deepEqual(merged.map((m) => m.id), ["x", "y", "z"]);
+});
+
+test("preferIncoming=false keeps existing on collision (defensive option)", () => {
+  const d1 = [msg("a1", "assistant", 2, { content: "keep me" })];
+  const think = [msg("a1", "assistant", 2, { content: "discard" })];
+  const merged = mergeTranscript(d1, think, { preferIncoming: false });
+  assert.equal(merged[0].content, "keep me");
+});
+
+test("no duplicate ids in output when both sides share ids", () => {
+  const d1 = [msg("u1", "user", 1), msg("a1", "assistant", 2)];
+  const think = [msg("u1", "user", 1), msg("a1", "assistant", 2)];
+  const merged = mergeTranscript(d1, think);
+  assert.equal(merged.length, 2);
+  assert.equal(new Set(merged.map((m) => m.id)).size, 2);
+});

--- a/proof/svelte/transcript-merge.test.ts
+++ b/proof/svelte/transcript-merge.test.ts
@@ -61,6 +61,26 @@ test("preferIncoming=false keeps existing on collision (defensive option)", () =
   assert.equal(merged[0].content, "keep me");
 });
 
+test("keepExistingOnlyIf drops D1-only synthetic tool rows but keeps real turns", () => {
+  // D1 restored: a real assistant turn (a1) + a synthetic tool row (d1-9).
+  // Think's replay omits both (compacted) but will re-render the tool inline.
+  const d1 = [msg("u1", "user", 1), msg("a1", "assistant", 2), msg("d1-9", "system", 3)];
+  const think = [msg("u1", "user", 1)];
+  const merged = mergeTranscript(d1, think, { keepExistingOnlyIf: (m) => !m.id.startsWith("d1-") });
+  assert.deepEqual(merged.map((m) => m.id), ["u1", "a1"]);
+  assert.ok(!merged.find((m) => m.id === "d1-9"), "synthetic tool row must be dropped");
+});
+
+test("keepExistingOnlyIf still keeps a d1- row if Think ALSO has that id (collision path)", () => {
+  // Defensive: if the same id appears on both sides, it's not existing-only, so the
+  // predicate does not apply and the incoming (Think) version is used.
+  const d1 = [msg("d1-9", "system", 3, { content: "d1" })];
+  const think = [msg("d1-9", "assistant", 3, { content: "think" })];
+  const merged = mergeTranscript(d1, think, { keepExistingOnlyIf: (m) => !m.id.startsWith("d1-") });
+  assert.equal(merged.length, 1);
+  assert.equal(merged[0].content, "think");
+});
+
 test("no duplicate ids in output when both sides share ids", () => {
   const d1 = [msg("u1", "user", 1), msg("a1", "assistant", 2)];
   const think = [msg("u1", "user", 1), msg("a1", "assistant", 2)];

--- a/proof/svelte/transcript-merge.ts
+++ b/proof/svelte/transcript-merge.ts
@@ -1,0 +1,74 @@
+// transcript-merge.ts — the fix for the large-thread "assistant replies lost" race.
+//
+// On resume, two transcripts arrive: the durable D1 eager restore (fast, complete)
+// and Think's cf_agent_chat_messages replay (authoritative content, but possibly
+// COMPACTED or still materializing). The old code did `messages = []` then rebuilt
+// from Think alone, so any message D1 had but Think's replay omitted (notably
+// assistant replies on a long/compacted thread) vanished from the view.
+//
+// mergeTranscript merges instead of replacing: Think's version WINS for a message
+// present in both (it's authoritative), but a message present only in the existing
+// (D1) view is KEPT. Alignment is by id — D1 view ids are `meta.uiMessageId || d1-<n>`
+// and Think view ids are `message.id`, and the server sets meta.uiMessageId =
+// message.id, so the same logical message shares an id across both sources.
+
+export type MergeableMessage = {
+  id: string;
+  role: string;
+  timestamp?: number;
+  // Opaque to the merge; carried through untouched.
+  [key: string]: unknown;
+};
+
+export type MergeOptions = {
+  // When true (Think replay), incoming entries override existing on id collision.
+  // The default is what the resume path wants.
+  preferIncoming?: boolean;
+};
+
+/**
+ * Merge two transcript views by id, keeping messages that exist in only one side.
+ *
+ * - id in BOTH: `preferIncoming` (default true) keeps the incoming (Think) version.
+ * - id only in `existing` (D1-only, e.g. an assistant reply Think compacted away): KEPT.
+ * - id only in `incoming`: added.
+ *
+ * Order: by timestamp ascending (chronological), stable for equal/absent timestamps
+ * using first-seen order across [existing, incoming]. This preserves the interleaving
+ * a user expects and never reorders equal-timestamp neighbors nondeterministically.
+ */
+export function mergeTranscript<T extends MergeableMessage>(
+  existing: T[],
+  incoming: T[],
+  options: MergeOptions = {},
+): T[] {
+  const preferIncoming = options.preferIncoming ?? true;
+
+  // First-seen order gives a stable tiebreaker for equal timestamps.
+  const order = new Map<string, number>();
+  let seq = 0;
+  const chosen = new Map<string, T>();
+
+  const consider = (msg: T, incomingSide: boolean) => {
+    if (!order.has(msg.id)) order.set(msg.id, seq++);
+    const prior = chosen.get(msg.id);
+    if (prior === undefined) {
+      chosen.set(msg.id, msg);
+      return;
+    }
+    // Collision: pick per preference. incomingSide === true means `msg` is from `incoming`.
+    if (incomingSide === preferIncoming) chosen.set(msg.id, msg);
+  };
+
+  for (const m of existing) consider(m, false);
+  for (const m of incoming) consider(m, true);
+
+  const merged = [...chosen.values()];
+  merged.sort((a, b) => {
+    const ta = typeof a.timestamp === "number" ? a.timestamp : Number.POSITIVE_INFINITY;
+    const tb = typeof b.timestamp === "number" ? b.timestamp : Number.POSITIVE_INFINITY;
+    if (ta !== tb) return ta - tb;
+    return (order.get(a.id) ?? 0) - (order.get(b.id) ?? 0);
+  });
+  return merged;
+}

--- a/proof/svelte/transcript-merge.ts
+++ b/proof/svelte/transcript-merge.ts
@@ -24,6 +24,14 @@ export type MergeOptions = {
   // When true (Think replay), incoming entries override existing on id collision.
   // The default is what the resume path wants.
   preferIncoming?: boolean;
+  // Predicate deciding whether an EXISTING (D1) message that Think's replay OMITTED
+  // may be retained. Needed because D1 tool rows render as standalone `system`
+  // messages with synthetic `d1-<n>` ids, but Think represents those same tool
+  // calls as INLINE parts of assistant messages — so keeping the D1 tool rows on
+  // top of Think's replay would DUPLICATE them. Only genuine turns that carry a
+  // real ui id (a user/assistant message Think may have compacted away) should be
+  // retained. Defaults to keeping everything (pure-merge semantics for tests).
+  keepExistingOnlyIf?: (msg: MergeableMessage) => boolean;
 };
 
 /**
@@ -43,6 +51,12 @@ export function mergeTranscript<T extends MergeableMessage>(
   options: MergeOptions = {},
 ): T[] {
   const preferIncoming = options.preferIncoming ?? true;
+  const keepExistingOnlyIf = options.keepExistingOnlyIf;
+
+  // A message that exists ONLY in `incoming` is always kept. An existing-only
+  // message is kept unless the caller's predicate rejects it (used to drop D1
+  // tool/synthetic rows that Think re-materializes inline).
+  const incomingIds = new Set(incoming.map((m) => m.id));
 
   // First-seen order gives a stable tiebreaker for equal timestamps.
   const order = new Map<string, number>();
@@ -60,7 +74,10 @@ export function mergeTranscript<T extends MergeableMessage>(
     if (incomingSide === preferIncoming) chosen.set(msg.id, msg);
   };
 
-  for (const m of existing) consider(m, false);
+  for (const m of existing) {
+    if (keepExistingOnlyIf && !incomingIds.has(m.id) && !keepExistingOnlyIf(m)) continue;
+    consider(m, false);
+  }
   for (const m of incoming) consider(m, true);
 
   const merged = [...chosen.values()];

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -537,7 +537,7 @@ export class MyAgent extends Think<Env> {
     const users = this.messages.filter((message) => message.role === "user");
     let insertedLatest = false;
     for (const message of users) {
-      const existing = await this.env.DB.prepare("SELECT id FROM conversation_entries WHERE session_id = ? AND owner_email = ? AND role = 'user' AND json_extract(meta_json, '$.uiMessageId') = ? LIMIT 1")
+      const existing = await this.env.DB.prepare("SELECT id FROM conversation_entries WHERE session_id = ? AND owner_email = ? AND role = 'user' AND ui_message_id = ? LIMIT 1")
         .bind(this.name, identity.email, message.id).first<{ id: number }>().catch(() => null);
       if (existing) continue;
       const attachments = attachmentParts(message);
@@ -582,7 +582,7 @@ export class MyAgent extends Think<Env> {
       })),
     );
     for (const message of candidates) {
-      const existing = await this.env.DB.prepare("SELECT id FROM conversation_entries WHERE session_id = ? AND owner_email = ? AND role = 'assistant' AND json_extract(meta_json, '$.uiMessageId') = ? LIMIT 1")
+      const existing = await this.env.DB.prepare("SELECT id FROM conversation_entries WHERE session_id = ? AND owner_email = ? AND role = 'assistant' AND ui_message_id = ? LIMIT 1")
         .bind(this.name, identity.email, message.id).first<{ id: number }>().catch(() => null);
       if (existing) continue;
       await logAssistantMessage(this.env, identity, this.name, message.text, {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -678,7 +678,15 @@ export class MyAgent extends Think<Env> {
     // the request's convenience email header as an authorization principal.
     super.onConnect(connection, ctx);
     this.logAcceptedUsers().catch((error) => console.error("think_user_log_sync_failed", { err: String(error) }));
-    this.reconcileAssistantHistory().catch((error) => console.error("think_assistant_log_sync_failed", { err: String(error) }));
+    // P1 transcript-race Stage 3: keep assistant-history reconciliation OFF the
+    // open hot path. It backfills assistant rows Think has but D1 missed
+    // (interrupted turns); it is idempotent and needed neither before first paint
+    // nor before the cf_agent_chat_messages replay. Defer it past onConnect via a
+    // macrotask so a long-thread open is never blocked by a per-assistant D1
+    // dedup pass on connect. The DO stays alive while the connection is open.
+    setTimeout(() => {
+      this.reconcileAssistantHistory().catch((error) => console.error("think_assistant_log_sync_failed", { err: String(error) }));
+    }, 0);
   }
 
   async onMessage(connection: Parameters<Think<Env>["onMessage"]>[0], message: unknown) {

--- a/src/conversation-log.ts
+++ b/src/conversation-log.ts
@@ -57,7 +57,7 @@ export async function appendConversationLog(
          WHERE NOT EXISTS (
            SELECT 1 FROM conversation_entries
            WHERE session_id = ? AND owner_email = ? AND role = ?
-             AND json_extract(meta_json, '$.uiMessageId') = ?
+             AND ui_message_id = ?
          )`,
       ).bind(
         sessionId, identity.email.toLowerCase(), entry.ts, entry.role, entry.tool ?? null, entry.isError ? 1 : 0, entry.content ?? null, metaJson,
@@ -71,7 +71,7 @@ export async function appendConversationLog(
          WHERE NOT EXISTS (
            SELECT 1 FROM conversation_entries
            WHERE session_id = ? AND owner_email = ? AND role = 'tool'
-             AND json_extract(meta_json, '$.toolCallId') = ?
+             AND tool_call_id = ?
          )`,
       ).bind(
         sessionId, identity.email.toLowerCase(), entry.ts, entry.role, entry.tool ?? null, entry.isError ? 1 : 0, entry.content ?? null, metaJson,

--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -4,7 +4,7 @@ import type { AppEnv } from "../app-env";
 import { getConnector, type ConnectorId } from "../connectors";
 import { makeOAuthClientStore } from "../oauth-store";
 import { mintBridgeTicket } from "../bridge";
-import { clampEntriesLimit, pageConversationEntries, parseEntriesCursor, type ConversationEntryRow } from "../session-entries";
+import { clampEntriesLimit, pageConversationEntries, pageConversationEntriesDesc, parseEntriesCursor, parseEntriesBeforeCursor, type ConversationEntryRow } from "../session-entries";
 import { getSessionAgent } from "../agent-stub";
 import { deleteSessionArtifacts } from "../artifacts";
 import { deleteSessionAudioMessages } from "../audio-messages";
@@ -317,15 +317,34 @@ export function registerSessionRoutes(app: Hono<AppEnv>) {
   app.get("/api/sessions/:id/entries", async (c) => {
     const id = c.req.param("id");
     const email = c.get("identity").email;
-    const after = parseEntriesCursor(c.req.query("after"));
     const limit = clampEntriesLimit(c.req.query("limit"));
-    if (after === null) {
-      return c.json<ApiResponse>({ ok: false, command: c.req.path, error: { code: "BAD_CURSOR", message: "after must be a non-negative conversation entry id" }, next_actions: [] }, 400);
-    }
     const owned = await c.env.DB.prepare("SELECT id FROM sessions WHERE id = ? AND owner_email = ?")
       .bind(id, email).first<{ id: string }>();
     if (!owned) {
       return c.json<ApiResponse>({ ok: false, command: c.req.path, error: { code: "NOT_FOUND", message: "session not found or not owned" }, next_actions: [] }, 404);
+    }
+
+    // P1 Stage 2: newest-first bounded page for fast first paint. `order=desc`
+    // reads `id < before ORDER BY id DESC LIMIT n+1` on the existing
+    // (session_id, id DESC) index, returns the page re-reversed to chronological
+    // with `olderCursor`/`hasOlder` to page further back on scroll-up. This is
+    // the resume hot path; the ASC `after` mode remains for idempotent forward
+    // polling / external readers.
+    if ((c.req.query("order") ?? "").toLowerCase() === "desc") {
+      const before = parseEntriesBeforeCursor(c.req.query("before"));
+      if (before === null) {
+        return c.json<ApiResponse>({ ok: false, command: c.req.path, error: { code: "BAD_CURSOR", message: "before must be a positive conversation entry id" }, next_actions: [] }, 400);
+      }
+      const descResult = await c.env.DB.prepare(
+        "SELECT id, ts, role, tool, is_error, content, meta_json FROM conversation_entries WHERE session_id = ? AND owner_email = ? AND id < ? ORDER BY id DESC LIMIT ?",
+      ).bind(id, email, before, limit + 1).all<ConversationEntryRow>();
+      const page = pageConversationEntriesDesc(descResult.results ?? [], limit);
+      return c.json<ApiResponse>({ ok: true, command: c.req.path, result: { sessionId: id, ...page }, next_actions: [] });
+    }
+
+    const after = parseEntriesCursor(c.req.query("after"));
+    if (after === null) {
+      return c.json<ApiResponse>({ ok: false, command: c.req.path, error: { code: "BAD_CURSOR", message: "after must be a non-negative conversation entry id" }, next_actions: [] }, 400);
     }
     const result = await c.env.DB.prepare(
       "SELECT id, ts, role, tool, is_error, content, meta_json FROM conversation_entries WHERE session_id = ? AND owner_email = ? AND id > ? ORDER BY id ASC LIMIT ?",

--- a/src/session-entries.test.ts
+++ b/src/session-entries.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  clampEntriesLimit,
+  parseEntriesBeforeCursor,
+  pageConversationEntriesDesc,
+  type ConversationEntryRow,
+} from "./session-entries";
+
+const row = (id: number, role = "user"): ConversationEntryRow => ({
+  id, ts: new Date(1_700_000_000_000 + id * 1000).toISOString(), role, tool: null, is_error: 0,
+  content: `m${id}`, meta_json: JSON.stringify({ uiMessageId: `ui-${id}` }),
+});
+
+// Rows come from `id < before ORDER BY id DESC LIMIT limit+1` — newest first.
+test("desc page returns chronological order for render", () => {
+  const rows = [row(50), row(49), row(48)]; // DESC from D1
+  const page = pageConversationEntriesDesc(rows, 10);
+  assert.deepEqual(page.entries.map((e) => e.id), ["48", "49", "50"]);
+  assert.equal(page.hasOlder, false);
+  assert.equal(page.olderCursor, "48");
+});
+
+test("desc page caps at limit and flags older history via the extra row", () => {
+  const rows = [row(50), row(49), row(48), row(47)]; // 4 rows, limit 3 => hasOlder
+  const page = pageConversationEntriesDesc(rows, 3);
+  assert.equal(page.entries.length, 3);
+  assert.deepEqual(page.entries.map((e) => e.id), ["48", "49", "50"]); // newest 3, chronological
+  assert.equal(page.hasOlder, true);
+  assert.equal(page.olderCursor, "48"); // page further back with before=48
+});
+
+test("empty session yields no entries, no older cursor", () => {
+  const page = pageConversationEntriesDesc([], 50);
+  assert.deepEqual(page.entries, []);
+  assert.equal(page.hasOlder, false);
+  assert.equal(page.olderCursor, null);
+});
+
+test("before cursor: absent => newest (MAX), digits ok, junk rejected", () => {
+  assert.equal(parseEntriesBeforeCursor(undefined), Number.MAX_SAFE_INTEGER);
+  assert.equal(parseEntriesBeforeCursor(""), Number.MAX_SAFE_INTEGER);
+  assert.equal(parseEntriesBeforeCursor("48"), 48);
+  assert.equal(parseEntriesBeforeCursor("-1"), null);
+  assert.equal(parseEntriesBeforeCursor("abc"), null);
+});
+
+test("limit clamps to [1,200] with default 50", () => {
+  assert.equal(clampEntriesLimit(undefined), 50);
+  assert.equal(clampEntriesLimit("100"), 100);
+  assert.equal(clampEntriesLimit("9999"), 200);
+  assert.equal(clampEntriesLimit("0"), 1);
+});

--- a/src/session-entries.ts
+++ b/src/session-entries.ts
@@ -20,12 +20,40 @@ export function parseEntriesCursor(raw: string | undefined): number | null {
   return Number.isSafeInteger(cursor) ? cursor : null;
 }
 
+function mapRow(row: ConversationEntryRow) {
+  let meta: unknown = null;
+  try { meta = row.meta_json ? JSON.parse(row.meta_json) : null; } catch { meta = row.meta_json; }
+  return { id: String(row.id), role: row.role, content: row.content ?? "", createdAt: row.ts, tool: row.tool, isError: row.is_error === 1, meta };
+}
+
 export function pageConversationEntries(rows: ConversationEntryRow[], limit: number, after: number) {
   const page = rows.slice(0, limit);
-  const entries = page.map((row) => {
-    let meta: unknown = null;
-    try { meta = row.meta_json ? JSON.parse(row.meta_json) : null; } catch { meta = row.meta_json; }
-    return { id: String(row.id), role: row.role, content: row.content ?? "", createdAt: row.ts, tool: row.tool, isError: row.is_error === 1, meta };
-  });
+  const entries = page.map(mapRow);
   return { entries, nextCursor: entries.at(-1)?.id ?? String(after), hasMore: rows.length > limit };
+}
+
+export function parseEntriesBeforeCursor(raw: string | undefined): number | null {
+  // Absent/empty => newest page (no upper bound). A provided value must be a
+  // positive integer id; anything else is rejected (fail closed).
+  if (raw === undefined || raw === "") return Number.MAX_SAFE_INTEGER;
+  if (!/^\d+$/.test(raw)) return null;
+  const cursor = Number(raw);
+  return Number.isSafeInteger(cursor) ? cursor : null;
+}
+
+/**
+ * Newest-first page: rows are fetched `id < before ORDER BY id DESC LIMIT limit+1`
+ * (cheap on idx_conversation_entries_session (session_id, id DESC)). We return
+ * them RE-REVERSED to chronological order for direct render, plus `olderCursor`
+ * (the smallest id in the page) to page further back, and `hasOlder` when more
+ * history exists before this page. This is the P1 Stage-2 fast first paint: one
+ * bounded page renders immediately instead of draining up to 20 oldest-first pages.
+ */
+export function pageConversationEntriesDesc(rows: ConversationEntryRow[], limit: number) {
+  const hasOlder = rows.length > limit;
+  const page = rows.slice(0, limit);           // newest-first, capped
+  const chronological = [...page].reverse();   // oldest-first for render
+  const entries = chronological.map(mapRow);
+  const olderCursor = entries.length ? entries[0].id : null; // smallest id shown
+  return { entries, olderCursor, hasOlder };
 }


### PR DESCRIPTION
Full P1 fix (supersedes #12). Deployed to prod (version 28a1be1b, SHA d038d92) and each stage verified live.

**S1 merge-not-clear** — renderThinkHistory merges Think's replay into the D1 restore instead of `messages = []`; D1-only assistant replies survive a compacted Think replay; synthetic `d1-` tool rows dropped (no dup). transcript-merge.ts, 10 tests.
**S2 newest-first bounded page** — `order=desc`/`before` on /entries (uses the (session_id,id DESC) index), one ≤100 page renders immediately, older pages on scroll-up. session-entries.ts, 15 tests. *Verified live:* desc returns chronological + olderCursor/hasOlder; before= pages older; junk→400; unowned→404.
**S3 reconcile off onConnect** — reconcileAssistantHistory deferred via setTimeout(0), off the open hot path.
**S4 index the dedup** — migration 0022 adds VIRTUAL generated columns (json_valid-guarded for 34 non-JSON rows) + indexes; dedup queries use them. *Verified live:* remote EXPLAIN shows SEARCH USING INDEX idx_conversation_entries_uimsgid.
**S5 sandbox off first paint** — audit only; already clean (sandbox/getUserWorkspace are tool-impl + turn-path, not connect).

2× audit each; full check gate green; deploy fail-closed (first two attempts correctly halted at the migration until it was D1-safe).