### PR TITLE
fix(transcript): load-time dup, missing older, scroll jump (L1 stability)

### DIFF
--- a/proof/svelte/Chat.svelte
+++ b/proof/svelte/Chat.svelte
@@ -1480,7 +1480,7 @@
     // P1 Stage 2: render ONE newest-first bounded page immediately instead of
     // draining up to 20 oldest-first 200-row pages before first paint. Older
     // history pages in on scroll-up via loadOlderHistory.
-    const result = await loadNewestEntries(expected, 100);
+    const result = await loadNewestEntries(expected, 200);
     if (result.outcome === "stale") return "stale";
     const restored: Message[] = result.entries.map(d1EntryToMessage);
     if (!sessionWorkIsCurrent(expected)) return "stale";
@@ -1512,9 +1512,13 @@
       // calls as inline assistant parts, so a standalone d1- system row would
       // duplicate an inline tool once the assistant turn is also shown. Keep only
       // genuine turns (real ui id) that aren't already in the view.
+      // #3 idempotent: never re-add an id already rendered. Drop synthetic d1- tool
+      // rows (Think renders those inline) AND anything already present, so repeated
+      // scroll-up paging can't duplicate the boundary rows.
+      const present = new Set(messages.map((m) => m.id));
       const older: Message[] = (r.entries ?? [])
         .map(d1EntryToMessage)
-        .filter((m: Message) => !m.id.startsWith("d1-"));
+        .filter((m: Message) => !m.id.startsWith("d1-") && !present.has(m.id));
       if (older.length) messages = mergeTranscript(older as any, messages as any) as typeof messages;
       olderHistoryCursor = r.hasOlder ? (r.olderCursor ?? "") : "";
     } catch {
@@ -1640,11 +1644,30 @@
     // turn (real ui id). D1 tool rows are synthetic `d1-<n>` system messages that
     // Think re-renders as inline assistant parts, so dropping them here avoids
     // duplicated tool output.
+    // #4 preserve scroll: capture whether the user was pinned at the bottom AND the
+    // pre-merge geometry BEFORE mutating `messages`, so the Think replay reconcile
+    // never yanks the viewport. If they were at the bottom we settle at the bottom;
+    // if they had scrolled up, we hold their position across any height change.
+    const wasPinned = logEl ? (logEl.scrollHeight - logEl.clientHeight - logEl.scrollTop < 80) : true;
+    const prevTop = logEl?.scrollTop ?? 0;
+    const prevHeight = logEl?.scrollHeight ?? 0;
     messages = thinkViews.length > 0
       ? mergeTranscript(priorMessages, thinkViews, { keepExistingOnlyIf: (m) => !m.id.startsWith("d1-") })
       : priorMessages;
     void hydrateHistoryTimestamps();
-    void revealResumedHistoryAtBottom();
+    if (wasPinned) {
+      void revealResumedHistoryAtBottom();
+    } else {
+      // #5 hold position without a smooth animation: restore scrollTop adjusted for
+      // the height delta the merge introduced, so nothing visibly jumps.
+      void tick().then(() => {
+        if (!logEl) return;
+        const prevBehavior = logEl.style.scrollBehavior;
+        logEl.style.scrollBehavior = "auto";
+        logEl.scrollTop = prevTop + (logEl.scrollHeight - prevHeight);
+        requestAnimationFrame(() => { if (logEl) logEl.style.scrollBehavior = prevBehavior; });
+      });
+    }
   }
 
   function handleThinkChunk(chunk: any) {

--- a/proof/svelte/transcript-merge.test.ts
+++ b/proof/svelte/transcript-merge.test.ts
@@ -10,6 +10,27 @@ const msg = (
 ): { id: string; role: string; timestamp?: number; content?: string; [k: string]: unknown } =>
   ({ id, role, timestamp, ...extra });
 
+// #1/#3 regression: the D1 REST read and the server Think replay now key the SAME
+// row identically (meta.uiMessageId || d1-<id>). Merging them must dedup, and
+// repeating the merge (every cf_agent_chat_messages replay) must be idempotent —
+// never growing the transcript or duplicating a message.
+test("merge of identically-keyed D1 + Think replay dedups (no duplication)", () => {
+  const d1 = [msg("ui-1", "user", 1), msg("ui-2", "assistant", 2), msg("ui-3", "user", 3)];
+  const think = [msg("ui-1", "user", 1), msg("ui-2", "assistant", 2), msg("ui-3", "user", 3)];
+  const merged = mergeTranscript(d1, think);
+  assert.equal(merged.length, 3);
+  assert.equal(new Set(merged.map((m) => m.id)).size, 3);
+});
+
+test("merge is idempotent under repeated Think replays", () => {
+  const d1 = [msg("ui-1", "user", 1), msg("ui-2", "assistant", 2)];
+  const think = [msg("ui-1", "user", 1), msg("ui-2", "assistant", 2)];
+  let m = mergeTranscript(d1, think);
+  for (let i = 0; i < 5; i++) m = mergeTranscript(m, think);
+  assert.equal(m.length, 2, "repeated replays must not grow the transcript");
+  assert.deepEqual(m.map((x) => x.id), ["ui-1", "ui-2"]);
+});
+
 // THE bug: D1 restored an assistant reply; Think's compacted replay omits it.
 test("keeps a D1-only assistant reply that Think's replay omitted", () => {
   const d1 = [msg("u1", "user", 1), msg("a1", "assistant", 2), msg("u2", "user", 3), msg("a2", "assistant", 4)];

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -431,14 +431,21 @@ app.all("/agents/*", async (c) => {
         // unavailable, preserving readable history during migration.
         if (!messages.length) {
           const rows = await c.env.DB.prepare(
-            "SELECT id, ts, role, content FROM conversation_entries WHERE session_id = ? AND owner_email = ? ORDER BY id ASC",
-          ).bind(sessionId, identity.email.toLowerCase()).all<{ id: number; ts: string; role: string; content: string }>();
-          messages = (rows.results ?? []).map((row) => ({
-            id: `legacy-d1:${row.id}`,
-            role: ["user", "assistant", "system"].includes(row.role) ? row.role as "user" | "assistant" | "system" : "system",
-            parts: [{ type: "text", text: row.role === "tool" ? `[tool result]\n${row.content}` : row.content }],
-            createdAt: new Date(row.ts),
-          }));
+            "SELECT id, ts, role, content, meta_json FROM conversation_entries WHERE session_id = ? AND owner_email = ? ORDER BY id ASC",
+          ).bind(sessionId, identity.email.toLowerCase()).all<{ id: number; ts: string; role: string; content: string; meta_json: string | null }>();
+          messages = (rows.results ?? []).map((row) => {
+            // Canonical id: MUST match the client's d1EntryToMessage keying
+            // (meta.uiMessageId || `d1-<id>`), so the D1 REST read and this Think
+            // replay dedup to the same message instead of double-rendering.
+            let uiMessageId: string | undefined;
+            try { uiMessageId = row.meta_json ? (JSON.parse(row.meta_json)?.uiMessageId as string | undefined) : undefined; } catch {}
+            return {
+              id: uiMessageId || `d1-${row.id}`,
+              role: ["user", "assistant", "system"].includes(row.role) ? row.role as "user" | "assistant" | "system" : "system",
+              parts: [{ type: "text", text: row.role === "tool" ? `[tool result]\n${row.content}` : row.content }],
+              createdAt: new Date(row.ts),
+            };
+          });
         }
         if (messages.length) await facet.importLegacyMessages(messages);
       }


### PR DESCRIPTION
Reproduced on a seeded 120-msg thread + Playwright. Three visible bugs, one root cause: D1 REST read and Think WS replay were merged by an id that didn't agree across sources.

- **#1 unify id** — server import (index.tsx) keys rows `meta.uiMessageId || d1-<id>` (matches client d1EntryToMessage); was `legacy-d1:<id>` → the two sources now dedup.
- **#3 idempotent** — loadOlderHistory skips already-present ids; +2 merge-idempotency unit tests.
- **#4 preserve scroll** — capture pinned-state + geometry before merge; settle at bottom only if pinned, else restore position + height delta.
- **#5 no animated jump** — force scroll-behavior:auto during programmatic reposition.
- first page loads 200 (server max) so typical threads render whole.

**Verified localhost** (fresh + warm DO, 3 refreshes): 120/120 msgs, 0 dupes, #1–120 present, stays pinned at bottom, no post-settle jumps. Full check green.