### PR TITLE
feat(composer): consolidate attach + camera into one [+] menu (L3)

### DIFF
--- a/proof/svelte/Chat.svelte
+++ b/proof/svelte/Chat.svelte
@@ -1756,6 +1756,13 @@
     (document.getElementById("svelte-image-file") as HTMLInputElement)?.click();
   }
 
+  // Consolidated composer "+" menu: Add File / Camera (Watch stream lands here later).
+  let plusMenuOpen = $state(false);
+  function togglePlusMenu() { plusMenuOpen = !plusMenuOpen; }
+  function closePlusMenu() { plusMenuOpen = false; }
+  function plusAddFile() { closePlusMenu(); openImageFile(); }
+  function plusCamera() { closePlusMenu(); void toggleCamera(); }
+
   // ── Webcam vision (#10): capture a still and attach it so the agent can see ──
   let cameraOn = $state(false);
   let cameraEl = $state<HTMLVideoElement | undefined>(undefined);
@@ -2480,26 +2487,58 @@
             class="hidden"
             onchange={onImageInputChange}
           />
-          <button
-            type="button"
-            onclick={openImageFile}
-            class="flex-none flex items-center justify-center rounded-lg w-11 h-11 border border-line bg-bg text-fg hover:border-brand/60"
-            aria-label="Attach image"
-            title="Attach image"
-          >＋</button>
-          <button
-            type="button"
-            onclick={cameraOn ? captureFrame : toggleCamera}
-            class="flex-none flex items-center justify-center rounded-lg w-11 h-11 border border-line bg-bg text-fg-mut hover:text-fg hover:border-brand/60 data-[on='1']:border-brand/60 data-[on='1']:text-brand data-[on='1']:bg-brand/10"
-            data-on={cameraOn ? "1" : "0"}
-            data-camera-button="1"
-            aria-label={cameraOn ? "Capture a webcam frame for the agent" : "Turn on your webcam so the agent can see"}
-            title={cameraOn ? "Capture frame" : "Show webcam to agent"}
-          >
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-              <path d="M23 7l-7 5 7 5V7z" /><rect x="1" y="5" width="15" height="14" rx="2" ry="2" />
-            </svg>
-          </button>
+          {#if cameraOn}
+            <!-- Camera active: the button becomes a direct "capture frame" action. -->
+            <button
+              type="button"
+              onclick={captureFrame}
+              class="flex-none flex items-center justify-center rounded-lg w-11 h-11 border border-brand/60 bg-brand/10 text-brand"
+              data-camera-button="1"
+              aria-label="Capture a webcam frame for the agent"
+              title="Capture frame"
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M23 7l-7 5 7 5V7z" /><rect x="1" y="5" width="15" height="14" rx="2" ry="2" />
+              </svg>
+            </button>
+          {:else}
+            <!-- Consolidated "+" menu: Add File / Camera (one entry point for all media). -->
+            <div class="relative flex-none">
+              {#if plusMenuOpen}
+                <!-- click-away backdrop -->
+                <button type="button" class="fixed inset-0 z-10 cursor-default" aria-label="Close menu" onclick={closePlusMenu}></button>
+                <div
+                  class="absolute bottom-full left-0 z-20 mb-2 min-w-[10rem] overflow-hidden rounded-lg border border-line bg-bg shadow-lg"
+                  role="menu"
+                  aria-label="Add to message"
+                >
+                  <button type="button" role="menuitem" onclick={plusAddFile}
+                    class="flex w-full items-center gap-2.5 px-3 py-2.5 text-left text-sm text-fg hover:bg-bg-alt">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+                    Add file
+                  </button>
+                  <button type="button" role="menuitem" onclick={plusCamera}
+                    class="flex w-full items-center gap-2.5 px-3 py-2.5 text-left text-sm text-fg hover:bg-bg-alt">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M23 7l-7 5 7 5V7z"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>
+                    Camera
+                  </button>
+                </div>
+              {/if}
+              <button
+                type="button"
+                onclick={togglePlusMenu}
+                class="flex items-center justify-center rounded-lg w-11 h-11 border border-line bg-bg text-fg hover:border-brand/60 data-[open='1']:border-brand/60 data-[open='1']:text-brand"
+                data-open={plusMenuOpen ? "1" : "0"}
+                data-plus-button="1"
+                aria-haspopup="menu"
+                aria-expanded={plusMenuOpen}
+                aria-label="Add file or camera"
+                title="Add…"
+              >
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+              </button>
+            </div>
+          {/if}
           <button
             type="submit"
             onclick={wsState.conn === "offline" ? retryConnection : onSendClick}

--- a/proof/svelte/chat-composer-smoke.mjs
+++ b/proof/svelte/chat-composer-smoke.mjs
@@ -35,8 +35,14 @@ assertIncludes(chat, 'if (resumingExistingSession) eagerRestoreFromD1(sessionGen
 assertIncludes(chat, 'restoreD1History(expected, true)', "the eager fast-path load is quiet (no recovery toast on a normal resume)");
 // #10 webcam vision: camera capture routes through the shared upload path so a
 // frame becomes a normal (removable) attachment the agent can see.
-assertIncludes(chat, 'data-camera-button="1"', "composer exposes a webcam capture control");
-assertIncludes(chat, 'onclick={cameraOn ? captureFrame : toggleCamera}', "camera button toggles on, then captures a frame");
+// Consolidated composer input: a single "+" menu (Add file / Camera) replaces the
+// separate attach + camera buttons. When the camera is on, the button becomes a
+// direct capture-frame control.
+assertIncludes(chat, 'data-plus-button="1"', "composer exposes a single + menu button");
+assertIncludes(chat, 'onclick={plusAddFile}', "the + menu has an Add file item");
+assertIncludes(chat, 'onclick={plusCamera}', "the + menu has a Camera item");
+assertIncludes(chat, 'data-camera-button="1"', "an active camera exposes a capture-frame control");
+assertIncludes(chat, 'onclick={captureFrame}', "the active-camera button captures a frame");
 assertIncludes(chat, 'await addImageFile(new File([blob], frameFilename()', "a captured frame is attached via the shared upload path");
 assertIncludes(chat, 'getUserMedia({ video: { facingMode: "user" }, audio: false })', "camera opens video-only in an explicit gesture (privacy)");
 assertIncludes(chat, 'data-camera-preview="1"', "a live preview shows what will be captured before sending");


### PR DESCRIPTION
The separate ＋ (attach) and camera buttons collapse into a single **[+]** popover → **Add file · Camera** (Watch stream slot lands here later). When the camera is active, the button becomes a direct capture-frame control (in-progress action not buried). Click-away closes; aria-haspopup/expanded + role=menu/menuitem.

Verified localhost (desktop + mobile): [+] opens with Add file/Camera, closes on backdrop + select. Composer smoke updated; full check green.