### PR TITLE
feat(artifact): return path from interactive Svelte artifacts to chat (FR-1)

### DIFF
--- a/proof/svelte/Chat.svelte
+++ b/proof/svelte/Chat.svelte
@@ -2113,9 +2113,42 @@
       }
     };
     const onStartersRefresh = () => { void loadStarters(); };
+    // Artifact -> chat bridge. An interactive Svelte artifact runs in a
+    // sandbox="allow-scripts" iframe (no same-origin), so its only channel back
+    // is window.parent.postMessage. It can send:
+    //   { type: "my-ax:artifact-submit", value: "<text>", send?: boolean }
+    // We accept it ONLY from a live artifact iframe on this page, validate the
+    // shape, bound the length, and drop it into the composer for the user to
+    // review. We do NOT auto-send unless the artifact explicitly asks AND the
+    // value is non-trivial — the human stays in the loop (no silent turns from
+    // sandboxed code). This is the previously-missing return path for
+    // create_svelte_artifact forms.
+    const artifactWindows = () => new Set(
+      [...document.querySelectorAll('iframe[data-tool-widget-frame="svelte-artifact"], iframe.svelte-artifact-frame')]
+        .map((f) => (f as HTMLIFrameElement).contentWindow)
+        .filter(Boolean),
+    );
+    const onArtifactMessage = (event: MessageEvent) => {
+      const data = event.data;
+      if (!data || data.type !== "my-ax:artifact-submit") return;
+      // Source must be one of THIS page's artifact iframes (not an arbitrary window).
+      if (!artifactWindows().has(event.source as Window)) return;
+      const raw = typeof data.value === "string" ? data.value : "";
+      const value = raw.slice(0, 4000).trim();
+      if (!value) return;
+      if (composerLocked) return; // don't stomp an in-flight turn
+      composerText = value;
+      autoGrow();
+      inputEl?.focus();
+      // Auto-send only on an explicit, trusted request for a substantive value.
+      if (data.send === true && value.length >= 1 && !composerLocked) {
+        void onSendClick();
+      }
+    };
     window.addEventListener("my-ax:switch-session", onSwitch as EventListener);
     window.addEventListener("my-ax:navigate", onNavigate as EventListener);
     window.addEventListener("my-ax:starters-refresh", onStartersRefresh);
+    window.addEventListener("message", onArtifactMessage);
     navigator.serviceWorker?.addEventListener("message", onServiceWorkerMessage);
     return () => {
       window.removeEventListener("my-ax:deploy-update", onDeployUpdate);
@@ -2124,6 +2157,7 @@
       document.removeEventListener("visibilitychange", onVisibilityChange);
       window.removeEventListener("my-ax:switch-session", onSwitch as EventListener);
       window.removeEventListener("my-ax:navigate", onNavigate as EventListener);
+      window.removeEventListener("message", onArtifactMessage);
       navigator.serviceWorker?.removeEventListener("message", onServiceWorkerMessage);
       window.removeEventListener("online", onVisibilityChange);
       if (connectionWatchdogId) clearInterval(connectionWatchdogId);

--- a/proof/svelte/ToolResultWidget.svelte
+++ b/proof/svelte/ToolResultWidget.svelte
@@ -99,6 +99,7 @@
       {/if}
       <iframe
         class="svelte-artifact-frame"
+        data-tool-widget-frame="svelte-artifact"
         src={widget.src}
         title={widget.title}
         loading="lazy"

--- a/proof/svelte/chat-composer-smoke.mjs
+++ b/proof/svelte/chat-composer-smoke.mjs
@@ -62,6 +62,11 @@ for (const marker of ['CONNECTOR_REAUTH_REQUIRED', 'my_ax_connector_reauth']) {
 assertIncludes(chat, 'class="connector-banner__cta"', "connector reauth banner keeps an explicit owner CTA");
 assertIncludes(chat, 'Authorization failed for ${connector}. Tap "Authorize" to try again.', "OAuth callback toast does not reflect raw provider reason text");
 assertNotIncludes(chat, 'Authorization failed for ${connector}${reason', "OAuth callback toast must not include raw reason query text");
+// FR-1: interactive artifacts can post an answer back to the chat composer.
+assertIncludes(chat, 'my-ax:artifact-submit', "chat listens for artifact form submissions");
+assertIncludes(chat, 'artifactWindows()', "artifact submits are accepted only from live artifact iframes (anti-spoof)");
+assertIncludes(chat, 'window.addEventListener("message", onArtifactMessage)', "the artifact message bridge is wired");
+
 assertIncludes(appCss, '.connector-banner[data-state="upstream-auth"]', "connector upstream-auth banner state is visibly styled (in the compiled stylesheet)");
 assertNotIncludes(appCss, '#send', "global CSS must not define stale #send composer selectors");
 assertNotIncludes(appCss, '#theme-cycle', "global CSS must not define stale #theme-cycle selectors");

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -105,7 +105,7 @@ export const TOOLS: ToolDef[] = [
   },
   {
     name: "create_svelte_artifact",
-    description: "Create one durable interactive Svelte 5 artifact attached to this conversation and rendered inline in chat. Use when the user asks for a widget, visualization, dashboard, interactive explainer, calculator, or other useful UI artifact. Each call creates a new one-off artifact: do not treat this as a revision workflow. Source must be a complete self-contained .svelte component using Svelte 5 runes and no external imports. The artifact runs in a sandboxed iframe with no owner credentials; only the Svelte runtime module CDN required to mount it is permitted.",
+    description: "Create one durable interactive Svelte 5 artifact attached to this conversation and rendered inline in chat. Use when the user asks for a widget, visualization, dashboard, interactive explainer, calculator, form, or other useful UI artifact. Each call creates a new one-off artifact: do not treat this as a revision workflow. Source must be a complete self-contained .svelte component using Svelte 5 runes and no external imports. The artifact runs in a sandboxed iframe with no owner credentials; only the Svelte runtime module CDN required to mount it is permitted. TO SEND A RESULT BACK TO THE CHAT (e.g. a submitted form answer), call `window.parent.postMessage({ type: 'my-ax:artifact-submit', value: '<text to place in the composer>', send: false }, '*')`. The value lands in the message composer for the user to review and send; pass `send: true` only to submit it immediately on the user's behalf. This is the only channel out of the sandbox.",
     parameters: {
       type: "object",
       properties: {


### PR DESCRIPTION
Feedback FR-1: embedded interactive Svelte artifacts (forms, calculators) had **no way to send a submitted answer back** — the iframe is sandbox=allow-scripts with zero parent-side message receiver, so the tool advertised 'interactive' but the return channel was never built.

**Fix — a guarded artifact→chat bridge:**
- artifact calls `window.parent.postMessage({type:'my-ax:artifact-submit', value, send?}, '*')`
- chat accepts it **only from a live artifact iframe** on the page (anti-spoof: `event.source` must be one of our `.svelte-artifact-frame` windows), bounds value to 4000 chars, won't stomp an in-flight turn, drops it in the composer for review, auto-sends only on explicit `send:true`.
- `create_svelte_artifact` tool description documents the contract.

**Verified (Playwright, localhost):** artifact postMessage → lands in composer ✅; spoofed same-page message → ignored ✅. Smoke test added; full check green.