### PR TITLE
fix(turn): watchdog for silently-stalled turn (FR-2)

### DIFF
--- a/proof/svelte/Chat.svelte
+++ b/proof/svelte/Chat.svelte
@@ -471,6 +471,11 @@
   let turnState = $state<StreamingTurnState>(idleStreamingTurnState);
 
   function dispatchTurn(event: StreamingTurnEvent) {
+    // FR-2: stamp every turn transition so the watchdog can tell a genuinely
+    // active turn (frames arriving) from a silently-stalled one (locked but no
+    // frames for a long time, even though the socket is healthy).
+    lastTurnFrameAt = Date.now();
+    turnStallSurfaced = false;
     const next = transitionStreamingTurn(turnState, event);
     turnState = next;
     if (next.tag !== "active") {
@@ -976,6 +981,10 @@
   // stream chunks after a reconnect or a foreground resume probe.
   let responseRecoveryPending = false;
   let lastSocketActivityAt = Date.now();
+  // FR-2: last time ANY turn frame moved the FSM; the stall watchdog uses this.
+  let lastTurnFrameAt = Date.now();
+  let turnStallSurfaced = false;
+  const TURN_STALL_MS = 45_000;
   let connectionWatchdogId: ReturnType<typeof setInterval> | null = null;
   const ACTIVE_TURN_KEY_PREFIX = "my-ax-active-turn:";
 
@@ -2064,6 +2073,25 @@
         (ws as any).send(JSON.stringify({ type: "my_ax_ping", at: Date.now() }));
       }
       if (responseRecoveryPending && age > 15_000) responseRecoveryPending = false;
+      // FR-2: silently-stalled turn. The socket is OPEN and recently active (so
+      // it's not a disconnect), the composer is locked on an active turn, but no
+      // turn frame has moved the FSM for TURN_STALL_MS. Surface a truthful,
+      // NON-destructive affordance: tell the owner the agent went quiet and
+      // unlock the composer so they can retry/steer. We do NOT cancel the turn —
+      // a genuinely-slow server turn can still land and reconcile via the normal
+      // frame/adopt path. Fire once per stall (turnStallSurfaced resets on the
+      // next real frame in dispatchTurn).
+      if (
+        !turnStallSurfaced &&
+        composerLocked &&
+        (ws as any).readyState === WebSocket.OPEN &&
+        Date.now() - lastTurnFrameAt > TURN_STALL_MS
+      ) {
+        turnStallSurfaced = true;
+        pushSystem("The agent has gone quiet without finishing this turn. It may still be working — you can wait, or send another message to retry or steer.");
+        dispatchTurn({ type: "frame", frame: { requestId: activeRequestId, done: true } });
+        applyStatus("idle");
+      }
     }, 5_000);
 
     const onDeployUpdate = (event: Event) => {

--- a/proof/svelte/chat-composer-smoke.mjs
+++ b/proof/svelte/chat-composer-smoke.mjs
@@ -67,6 +67,12 @@ assertIncludes(chat, 'my-ax:artifact-submit', "chat listens for artifact form su
 assertIncludes(chat, 'artifactWindows()', "artifact submits are accepted only from live artifact iframes (anti-spoof)");
 assertIncludes(chat, 'window.addEventListener("message", onArtifactMessage)', "the artifact message bridge is wired");
 
+// FR-2: a silently-stalled turn (socket healthy, no frames) must self-recover
+// into a truthful, non-destructive retry affordance instead of locking forever.
+assertIncludes(chat, "TURN_STALL_MS", "a turn-stall threshold exists");
+assertIncludes(chat, "gone quiet without finishing", "stalled turn surfaces a truthful notice");
+assertIncludes(chat, "lastTurnFrameAt", "the watchdog tracks the last turn frame time");
+
 assertIncludes(appCss, '.connector-banner[data-state="upstream-auth"]', "connector upstream-auth banner state is visibly styled (in the compiled stylesheet)");
 assertNotIncludes(appCss, '#send', "global CSS must not define stale #send composer selectors");
 assertNotIncludes(appCss, '#theme-cycle', "global CSS must not define stale #theme-cycle selectors");


### PR DESCRIPTION
Feedback FR-2: a turn could spin 'thinking' forever — no reply, no error, composer locked. Existing recovery only fires on reconnect; a turn whose terminal frame never arrives had no client escape.

**Fix:** turn-stall watchdog in the existing 5s interval. If composer is locked on an active turn AND socket is OPEN (not a disconnect) AND no turn frame for 45s → surface a truthful non-destructive notice + unlock the composer (dispatch terminal done + idle). **Does NOT cancel** — a slow server turn can still land and reconcile. Fires once per stall.

Verified: TSC + build + full check green; FSM active→done→unlock already tested; smoke assertions added.