### PR TITLE
feat(beta): single-root frontend at /beta (L1 scaffold)

### DIFF
--- a/proof/svelte/BetaApp.svelte
+++ b/proof/svelte/BetaApp.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  // BetaApp.svelte — the proper my.ax frontend: ONE single-root Svelte app that
+  // nests the core surfaces as child components, instead of the prod shell's
+  // separate hydration mounts wired together with window events. Same
+  // @my-ax/store, same API/WS, same child components (1:1 baseline) — assembled
+  // as a cohesive tree so state flows by props/store within one mount.
+  //
+  // Served at /beta (additive, behind the same Access). Prod / is untouched.
+  //
+  // NOTE (L1 scaffold): ComputerHealth + Connectors still render as sibling
+  // nodes that Settings relocates into its Connections tab (the existing
+  // mechanism), kept identical here for 1:1 behavior. Converting that to a
+  // Svelte snippet slot is a bounded follow-up (L3) that removes the last
+  // DOM-move; not required for single-root parity of the main tree.
+  import AppShell from "./AppShell.svelte";
+  import Chat from "./Chat.svelte";
+  import Sessions from "./Sessions.svelte";
+  import Settings from "./Settings.svelte";
+  import ComputerHealth from "./ComputerHealth.svelte";
+  import Connectors from "./Connectors.svelte";
+
+  interface Props {
+    identityEmail?: string | null;
+    initialTheme?: "system" | "light" | "dark";
+  }
+  const { identityEmail = null, initialTheme = "system" }: Props = $props();
+</script>
+
+<div class="h-full flex flex-col">
+  <AppShell {identityEmail} />
+  <div class="flex-1 min-h-0 flex flex-col">
+    <Chat />
+  </div>
+</div>
+
+<Sessions />
+<Settings {identityEmail} {initialTheme} />
+
+<!-- Panels Settings relocates into its Connections tab (same mechanism as prod). -->
+<div id="settings-drawer-extra-mounts" class="hidden" aria-hidden="true">
+  <ComputerHealth />
+  <Connectors />
+</div>

--- a/proof/svelte/build.mjs
+++ b/proof/svelte/build.mjs
@@ -47,6 +47,7 @@ const result = await buildHonoSvelte({
     appshell: here("AppShell.svelte"),
     checkin: here("CheckIn.svelte"),
     chat: here("Chat.svelte"),
+    beta: here("BetaApp.svelte"),
   },
   // Module imported by multiple components and holding cross-component
   // $state. Without `sharedModules`, each component would inline its own
@@ -69,7 +70,7 @@ for (const [id, sz] of Object.entries(result.bundleSizes)) {
 // ── 2. Pre-compiled <Name>.ssr.mjs modules for each component, imported ──
 // Wrangler's bundler doesn't know how to load .svelte files; we hand it a
 // plain .mjs that imports svelte/server.
-for (const name of ["ComputerHealth", "Connectors", "Sessions", "Settings", "AppShell", "CheckIn", "Chat"]) {
+for (const name of ["ComputerHealth", "Connectors", "Sessions", "Settings", "AppShell", "CheckIn", "Chat", "BetaApp"]) {
   await build({
     entryPoints: [here(`${name}.svelte`)],
     bundle: true,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,6 +17,7 @@ function isVoiceEnabled(env: Env): boolean {
 }
 import { getUserWorkspace } from "./workspace";
 import { ChatPage } from "./views/ChatPage";
+import { BetaPage } from "./views/BetaPage";
 import type { AppEnv } from "./app-env";
 import { deploymentVersionResponse } from "./deploy-version";
 import { oauthStoreFor } from "./oauth-store";
@@ -179,6 +180,7 @@ app.use("/machinectl/*", accessMiddleware());
 // non-personalized /offline fallback stay anonymous so install metadata,
 // browser JS, and offline recovery don't have to re-auth on every fetch.
 app.use("/", accessMiddleware());
+app.use("/beta", accessMiddleware());
 // Gate BOTH the base rendered path and every rendered subroute (e.g.
 // POST /attention/seen). In Hono, app.use("/attention", ...) alone only
 // matches the exact path, so mutating subroutes silently bypassed the
@@ -521,6 +523,23 @@ app.get("/", (c) => {
   const theme = readThemeCookie(c);
   return c.html(
     <ChatPage
+      identityEmail={identity?.email ?? null}
+      buildId={buildId}
+      buildTimestamp={c.env.CF_VERSION_METADATA?.timestamp ?? undefined}
+      theme={theme}
+      appOrigin={c.env.BRIDGE_BASE_URL || new URL(c.req.url).origin}
+    />,
+  );
+});
+
+// /beta — the proper single-root frontend (BetaApp). Additive + behind the same
+// Access; prod / is untouched. Cutover to / happens only when explicitly chosen.
+app.get("/beta", (c) => {
+  const identity = c.get("identity");
+  const buildId = c.env.CF_VERSION_METADATA?.id ?? undefined;
+  const theme = readThemeCookie(c);
+  return c.html(
+    <BetaPage
       identityEmail={identity?.email ?? null}
       buildId={buildId}
       buildTimestamp={c.env.CF_VERSION_METADATA?.timestamp ?? undefined}

--- a/src/views/BetaPage.tsx
+++ b/src/views/BetaPage.tsx
@@ -1,0 +1,38 @@
+// views/BetaPage.tsx — the /beta frontend shell. ONE Svelte mount (BetaApp)
+// instead of ChatPage's six. Same Layout <head>, same API/WS, behind the same
+// Access. Additive: prod / (ChatPage) is untouched.
+import type { FC } from "hono/jsx";
+import { Layout, type ThemePref } from "./Layout";
+import { SvelteEmbed } from "../../proof/svelte/SvelteEmbed";
+// @ts-expect-error -- pre-compiled Svelte SSR module, no .d.ts.
+import BetaAppComponent from "../../proof/svelte/BetaApp.ssr.mjs";
+
+interface BetaPageProps {
+  identityEmail?: string | null;
+  buildId?: string;
+  buildTimestamp?: string;
+  theme?: ThemePref;
+  appOrigin?: string;
+}
+
+export const BetaPage: FC<BetaPageProps> = (props) => {
+  return (
+    <Layout
+      title="My Agent Experience (beta)"
+      identityEmail={props.identityEmail}
+      bodyClass="overflow-hidden"
+      buildId={props.buildId}
+      buildTimestamp={props.buildTimestamp}
+      theme={props.theme}
+      appOrigin={props.appOrigin}
+    >
+      <SvelteEmbed
+        component={BetaAppComponent}
+        hydrateAs="beta"
+        props={{ identityEmail: props.identityEmail ?? null, initialTheme: props.theme ?? "system" }}
+        buildId={props.buildId}
+        wrapperClass="contents"
+      />
+    </Layout>
+  );
+};


### PR DESCRIPTION
Start of the proper my.ax frontend — one cohesive Svelte app vs the prod shell's 6 hydration mounts + window-event glue + runtime DOM-node moving.

- **BetaApp.svelte**: single root nesting AppShell+Chat+Sessions+Settings(+panels) as child components in ONE mount. Same @my-ax/store, same children, same API/WS.
- **/beta** route (Access-gated) + BetaPage.tsx. Registered in build.mjs.

**ADDITIVE + ISOLATED:** prod / and all routes untouched; /beta behind the same Access, invisible to normal use. Cutover is a later explicit swap.

Verified localhost: /beta renders 1:1 (header, 120-msg transcript at bottom, composer) as one bundle. Full check green. L2–L4 tracked in the loop STATE.