### PR TITLE
fix(beta): definite-height mount + artifact send:true submits (L4/L2 audit)

### DIFF
--- a/proof/svelte/Chat.svelte
+++ b/proof/svelte/Chat.svelte
@@ -2169,8 +2169,11 @@
       autoGrow();
       inputEl?.focus();
       // Auto-send only on an explicit, trusted request for a substantive value.
+      // Use the real form submit path (requestSubmit) — onSendClick is the
+      // cancel-active-turn CLICK handler and early-returns while idle, so it
+      // never actually sent the message (FR-1/L2 R3 defect).
       if (data.send === true && value.length >= 1 && !composerLocked) {
-        void onSendClick();
+        queueMicrotask(() => formEl?.requestSubmit());
       }
     };
     window.addEventListener("my-ax:switch-session", onSwitch as EventListener);

--- a/proof/svelte/chat-composer-smoke.mjs
+++ b/proof/svelte/chat-composer-smoke.mjs
@@ -126,6 +126,18 @@ assertIncludes(appCss, '#svelte-hono-chat-root {', "chat mount must be made a fi
     if (!block.includes(decl)) throw new Error(`chat mount fill rule must include ${JSON.stringify(decl)}`);
   }
 }
+// /beta single-root mount: sits directly under body.app-viewport (fixed, NOT a
+// flex container), so it needs an explicit height:100% — flex:1 can't fill a
+// non-flex parent. Without this the composer floats mid-screen on an empty
+// thread and <body> (not <main>) owns scroll on a long one.
+assertIncludes(appCss, '#svelte-hono-beta-root {', "beta mount must have a definite-height rule (unbroken h-full chain)");
+{
+  const i = appCss.indexOf('#svelte-hono-beta-root {');
+  const block = appCss.slice(i, i + 160);
+  for (const decl of ['height: 100%;', 'min-height: 0;', 'display: flex;', 'flex-direction: column;']) {
+    if (!block.includes(decl)) throw new Error(`beta mount fill rule must include ${JSON.stringify(decl)}`);
+  }
+}
 // The chat embed must forward wrapperClass="contents" so the generic mount
 // wrapper does not re-break the height chain the CSS rule depends on.
 assertIncludes(chatPage, 'hydrateAs="chat"', "ChatPage mounts the chat embed");

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -782,6 +782,19 @@ html {
   flex-direction: column;
 }
 
+/* /beta single-root mount. Unlike #svelte-hono-chat-root (a flex child inside
+ * ChatPage's flex column), #svelte-hono-beta-root sits directly under
+ * body.app-viewport, which is position:fixed;inset:0 (definite height) but is
+ * NOT a flex container — so flex:1 can't fill it. Give the mount an explicit
+ * 100% height so BetaApp's h-full / flex-1 / min-h-0 chain resolves and the
+ * composer pins to the viewport bottom with <main> owning the scroll. */
+#svelte-hono-beta-root {
+  height: 100%;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
 /* apple-mobile-web-app-status-bar-style=black-translucent lets the app draw
  * underneath the OS status bar. Reserve the top safe area on chrome. */
 .safe-area-appbar {


### PR DESCRIPTION
Two verified findings from the parallel /beta parity audit (terrarium lanes L4 + L2):

**L4-R1 (breaks /beta layout):** `#svelte-hono-beta-root` had no CSS rule. It sits directly under `body.app-viewport` (fixed, not a flex container), so `flex:1` can't fill it → BetaApp's h-full chain broke → composer floated mid-screen (empty thread) / body owned scroll (long thread). Fix: `height:100%;min-height:0;display:flex;column`. **Verified live** (both long + empty threads: composer pinned, `<main>` scrolls).

**L2-R3 (artifact bridge defect, prod too):** `send:true` called `onSendClick()` — the cancel-turn click handler that early-returns while idle → auto-send never fired. Fix: `formEl.requestSubmit()`. **Verified live:** send:true clears composer + posts a real user turn.

Smoke test requires the beta mount fill rule. Full check green.