### PR TITLE
fix: Worker PR body is a stub and cannot be reviewed

### DIFF
--- a/agents/src/harness.test.ts
+++ b/agents/src/harness.test.ts
@@ -12,7 +12,7 @@ function ports(ok = true): { github: GithubPort; terrarium: TerrariumPort; label
     github: {
       async labelIssue(_n, next) { labels.push(...next); },
       async comment() {},
-      async openDraftPr() { return { number: 1 }; },
+      async openReadyPr() { return { number: 1 }; },
       async mergePr() { throw new Error("forbidden GitHub action: merge"); },
       async approvePr() { throw new Error("forbidden GitHub action: approve"); },
     },

--- a/agents/src/orchestrate.ts
+++ b/agents/src/orchestrate.ts
@@ -17,7 +17,7 @@ export const PROOF_COMMAND = "npx tsx --test src/desk-board.test.ts agents/src/p
 export interface GithubPort {
   labelIssue(number: number, labels: string[]): Promise<void>;
   comment(number: number, body: string): Promise<void>;
-  openDraftPr(input: { title: string; body: string; head: string }): Promise<{ number: number }>;
+  openReadyPr(input: { title: string; body: string; head: string }): Promise<{ number: number }>;
   mergePr(number: number): Promise<void>;
   approvePr(number: number): Promise<void>;
 }
@@ -36,7 +36,7 @@ export type TriageStep =
   | { step: "classify"; classification: Classification }
   | { step: "label"; labels: string[] }
   | { step: "comment" }
-  | { step: "draft"; number: number }
+  | { step: "pr"; number: number }
   | { step: "dig"; runId: string; verified: boolean }
   | { step: "visual"; accepted: boolean }
   | { step: "stop"; reason: string };
@@ -71,12 +71,16 @@ export async function runTriage(input: IssueInput, ports: { github: GithubPort; 
     return steps;
   }
   if (shouldOpenDraft(classification)) {
-    const pr = await ports.github.openDraftPr({
+    if (!input.number) {
+      steps.push({ step: "stop", reason: "issue number required before opening a PR" });
+      return steps;
+    }
+    const pr = await ports.github.openReadyPr({
       title: formatReadyPrTitle(input),
       body: formatReadyPrBody(input, classification),
-      head: "bot/issue-draft",
+      head: `bot/issue-${input.number}`,
     });
-    steps.push({ step: "draft", number: pr.number });
+    steps.push({ step: "pr", number: pr.number });
     return steps;
   }
   steps.push({ step: "stop", reason: classification.spray ? "spray" : "no-draft" });
@@ -94,24 +98,22 @@ export function formatReadyPrTitle(input: IssueInput): string {
 }
 
 export function formatReadyPrBody(input: IssueInput, classification: Classification): string {
-  const issueUrl = input.number ? `https://github.com/acoyfellow/my-ax/issues/${input.number}` : "(issue number missing)";
+  if (!input.number) throw new Error("issue number required before opening a PR");
   return [
-    `Closes ${issueUrl}`,
+    `Closes #${input.number}`,
     "",
     "## Why",
     classification.summary,
     "",
     "## Receipt",
+    `- issue: https://github.com/acoyfellow/my-ax/issues/${input.number}`,
     `- kind: ${classification.kind}`,
     `- severity: ${classification.severity}`,
     `- labels: ${classification.labels.join(", ") || "none"}`,
     `- visual: ${classification.visual}`,
     "",
     "## Files",
-    "- `src/desk-board.ts`",
-    "- `src/desk-board.test.ts`",
-    "- `agents/src/orchestrate.ts`",
-    "- `agents/src/ports.ts`",
+    "See the Files changed tab on this PR. This body does not invent a file list.",
     "",
     "## Proof",
     "```sh",

--- a/agents/src/orchestrate.ts
+++ b/agents/src/orchestrate.ts
@@ -12,6 +12,8 @@ import {
   verifyTerrariumReceipt,
 } from "./policy";
 
+export const PROOF_COMMAND = "npx tsx --test src/desk-board.test.ts agents/src/policy.test.ts agents/src/harness.test.ts agents/src/github-hmac.test.ts";
+
 export interface GithubPort {
   labelIssue(number: number, labels: string[]): Promise<void>;
   comment(number: number, body: string): Promise<void>;
@@ -70,8 +72,8 @@ export async function runTriage(input: IssueInput, ports: { github: GithubPort; 
   }
   if (shouldOpenDraft(classification)) {
     const pr = await ports.github.openDraftPr({
-      title: `bot: ${input.title}`,
-      body: "Machine draft. Not reviewed. Human merge only.",
+      title: formatReadyPrTitle(input),
+      body: formatReadyPrBody(input, classification),
       head: "bot/issue-draft",
     });
     steps.push({ step: "draft", number: pr.number });
@@ -85,6 +87,39 @@ export async function runAudit(input: PullInput, ports: { github: GithubPort; pr
   const receipt = auditPull(input, ports.promptDigest);
   await ports.github.comment(input.number ?? 0, formatAuditComment(receipt));
   return receipt;
+}
+
+export function formatReadyPrTitle(input: IssueInput): string {
+  return input.title.replace(/^bug:\s*/i, "fix: ").slice(0, 120);
+}
+
+export function formatReadyPrBody(input: IssueInput, classification: Classification): string {
+  const issueUrl = input.number ? `https://github.com/acoyfellow/my-ax/issues/${input.number}` : "(issue number missing)";
+  return [
+    `Closes ${issueUrl}`,
+    "",
+    "## Why",
+    classification.summary,
+    "",
+    "## Receipt",
+    `- kind: ${classification.kind}`,
+    `- severity: ${classification.severity}`,
+    `- labels: ${classification.labels.join(", ") || "none"}`,
+    `- visual: ${classification.visual}`,
+    "",
+    "## Files",
+    "- `src/desk-board.ts`",
+    "- `src/desk-board.test.ts`",
+    "- `agents/src/orchestrate.ts`",
+    "- `agents/src/ports.ts`",
+    "",
+    "## Proof",
+    "```sh",
+    PROOF_COMMAND,
+    "```",
+    "",
+    "Worker never merges. Worker never approves. Human merge only.",
+  ].join("\n");
 }
 
 export function formatAuditComment(receipt: AuditReceipt): string {

--- a/agents/src/policy.test.ts
+++ b/agents/src/policy.test.ts
@@ -19,7 +19,7 @@ function memoryGithub(): GithubPort & { actions: string[] } {
     actions,
     async labelIssue(_n, labels) { actions.push(`label:${labels.join(",")}`); },
     async comment() { actions.push("comment"); },
-    async openDraftPr(input) { actions.push(`draft:${input.title}`); actions.push(`body:${input.body}`); return { number: 7 }; },
+    async openReadyPr(input) { actions.push(`pr:${input.title}`); actions.push(`head:${input.head}`); actions.push(`body:${input.body}`); return { number: 7 }; },
     async mergePr() { actions.push("merge"); },
     async approvePr() { actions.push("approve"); },
   };
@@ -48,10 +48,14 @@ test("ready PR body names the issue, proof command, and never-merge rule", () =>
   const classification = classifyIssue(input);
   const body = formatReadyPrBody(input, classification);
   assert.equal(formatReadyPrTitle(input), "fix: desk href allowlist untested for // and overlong github URLs");
+  assert.match(body, /Closes #40/);
   assert.match(body, /issues\/40/);
   assert.match(body, new RegExp(PROOF_COMMAND.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   assert.match(body, /never merges/i);
+  assert.match(body, /does not invent a file list/);
+  assert.doesNotMatch(body, /src\/desk-board\.ts/);
   assert.doesNotMatch(body, /Machine draft\. Not reviewed/);
+  assert.throws(() => formatReadyPrBody({ title: "x", body: "triage:draft", author: "o" }, classification));
 });
 
 test("triage:draft still opens a draft when the bug mentions PWA", () => {
@@ -73,7 +77,7 @@ test("spray never drafts", async () => {
   );
   assert.equal(steps[0]?.step === "classify" && steps[0].classification.spray, true);
   assert.equal(shouldOpenDraft(steps[0].step === "classify" ? steps[0].classification : classifyIssue({ title: "", body: "", author: "x" })), false);
-  assert.ok(!github.actions.includes("draft"));
+  assert.ok(!github.actions.some((action) => action.startsWith("pr:")));
   assert.ok(github.actions.includes("comment"));
 });
 

--- a/agents/src/policy.test.ts
+++ b/agents/src/policy.test.ts
@@ -10,7 +10,7 @@ import {
   shouldSpawnDig,
   verifyTerrariumReceipt,
 } from "./policy";
-import { runAudit, runTriage, type GithubPort, type TerrariumPort } from "./orchestrate";
+import { PROOF_COMMAND, formatReadyPrBody, formatReadyPrTitle, runAudit, runTriage, type GithubPort, type TerrariumPort } from "./orchestrate";
 import { executeTriageWorkflow } from "./workflows";
 
 function memoryGithub(): GithubPort & { actions: string[] } {
@@ -19,7 +19,7 @@ function memoryGithub(): GithubPort & { actions: string[] } {
     actions,
     async labelIssue(_n, labels) { actions.push(`label:${labels.join(",")}`); },
     async comment() { actions.push("comment"); },
-    async openDraftPr() { actions.push("draft"); return { number: 7 }; },
+    async openDraftPr(input) { actions.push(`draft:${input.title}`); actions.push(`body:${input.body}`); return { number: 7 }; },
     async mergePr() { actions.push("merge"); },
     async approvePr() { actions.push("approve"); },
   };
@@ -36,6 +36,22 @@ test("AGENTS_MODEL defaults to grok-4.6 and is overridable", () => {
   assert.equal(DEFAULT_AGENTS_MODEL, "grok-4.6");
   assert.equal(resolveAgentsModel({}), "grok-4.6");
   assert.equal(resolveAgentsModel({ AGENTS_MODEL: "kimi-k2.7" }), "kimi-k2.7");
+});
+
+test("ready PR body names the issue, proof command, and never-merge rule", () => {
+  const input = {
+    number: 40,
+    title: "bug: desk href allowlist untested for // and overlong github URLs",
+    body: "triage:draft\nmutant survivors on desk-board",
+    author: "owner",
+  };
+  const classification = classifyIssue(input);
+  const body = formatReadyPrBody(input, classification);
+  assert.equal(formatReadyPrTitle(input), "fix: desk href allowlist untested for // and overlong github URLs");
+  assert.match(body, /issues\/40/);
+  assert.match(body, new RegExp(PROOF_COMMAND.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.match(body, /never merges/i);
+  assert.doesNotMatch(body, /Machine draft\. Not reviewed/);
 });
 
 test("triage:draft still opens a draft when the bug mentions PWA", () => {

--- a/agents/src/ports.ts
+++ b/agents/src/ports.ts
@@ -35,8 +35,8 @@ export function liveGithubPort(env: AgentsEnv & { GITHUB_TOKEN?: string; GITHUB_
       assertNoMergeAction("comment");
       await gh(`/issues/${number}/comments`, { method: "POST", body: JSON.stringify({ body }) });
     },
-    async openDraftPr(input) {
-      assertNoMergeAction("openDraft");
+    async openReadyPr(input) {
+      assertNoMergeAction("openReadyPr");
       const json = await gh("/pulls", {
         method: "POST",
         body: JSON.stringify({ title: input.title, body: input.body, head: input.head, base: "main", draft: false }),


### PR DESCRIPTION
Closes #42

## Why
The previous Worker PR body invented a file list and used a classifier one-liner as the reason. Reviewers cannot trust that.

This change:
- writes `Closes #<n>` so GitHub can close the issue
- refuses to open a PR without an issue number
- drops the hardcoded Files list
- opens `bot/issue-<n>` instead of one shared `bot/issue-draft` ref
- names the GitHub call `openReadyPr` because it posts `draft: false`

## Receipt
- issue: https://github.com/acoyfellow/my-ax/issues/42
- kind: bug
- severity: p2
- labels: bug, triage:draft
- visual: none

## Files
See the Files changed tab on this PR. This body does not invent a file list.

## Proof
```sh
npx tsx --test src/desk-board.test.ts agents/src/policy.test.ts agents/src/harness.test.ts agents/src/github-hmac.test.ts
```

Worker never merges. Worker never approves. Human merge only.
