### PR TITLE
fix: audit files, one-hop labels, desk status tests

### DIFF
--- a/agents/HUNT.md
+++ b/agents/HUNT.md
@@ -1,0 +1,37 @@
+# Overnight hunt
+
+One tick finds one new, checkable issue. Then it stops that hunt.
+
+## Do
+
+1. Read open issues titled `bug:` / `perf:` / `test:` so you do not refile.
+2. Pick a different surface than the last filed issue.
+3. Prove one fact with a command, a file:line, or a live URL.
+4. File one GitHub issue. Title says `bug:`, `perf:`, or `test:`.
+5. Stop. Next tick starts at step 1.
+
+## Do not
+
+- Open a pull request.
+- Merge.
+- Comment a cockpit of Approve/Reject into the issue body.
+- Reuse an already-filed finding.
+- Name people.
+
+## Surfaces, in order, skip if already open
+
+1. `agents/src/worker.ts` webhook payloads
+2. `agents/src/ports.ts` GitHub hop count
+3. `src/desk-board.ts` remaining mutant survivors
+4. `src/session-turn.ts` composer lock
+5. `agents/src/policy.ts` classify / audit findings
+
+## Proof for a filed issue
+
+The body must include at least one of:
+
+- a command and its output
+- a permalink to file and line
+- a live issue, comment, or delivery URL
+
+If you cannot attach that, do not file.

--- a/agents/src/orchestrate.ts
+++ b/agents/src/orchestrate.ts
@@ -18,6 +18,8 @@ export interface GithubPort {
   labelIssue(number: number, labels: string[]): Promise<void>;
   comment(number: number, body: string): Promise<void>;
   openReadyPr(input: { title: string; body: string; head: string }): Promise<{ number: number }>;
+  listPullFiles?(number: number): Promise<string[]>;
+  commitsBehindMain?(headSha: string): Promise<number>;
   mergePr(number: number): Promise<void>;
   approvePr(number: number): Promise<void>;
 }

--- a/agents/src/policy.test.ts
+++ b/agents/src/policy.test.ts
@@ -4,10 +4,12 @@ import {
   DEFAULT_AGENTS_MODEL,
   acceptVisualProof,
   assertNoMergeAction,
+  auditPull,
   classifyIssue,
   resolveAgentsModel,
   shouldOpenDraft,
   shouldSpawnDig,
+  usableIssueLabels,
   verifyTerrariumReceipt,
 } from "./policy";
 import { PROOF_COMMAND, formatReadyPrBody, formatReadyPrTitle, runAudit, runTriage, type GithubPort, type TerrariumPort } from "./orchestrate";
@@ -112,6 +114,23 @@ test("unproven Terrarium receipt stops the graph", async () => {
     { github: memoryGithub(), terrarium: memoryTerrarium(false), model: { modelId: "grok-4.6" } },
   );
   assert.ok(steps.some((s) => s.step === "stop" && s.reason.includes("unproven")));
+});
+
+test("usableIssueLabels drops unknown names without a repo list", () => {
+  assert.deepEqual(usableIssueLabels(["bug", "triage:draft", "not-a-label"]), ["bug", "triage:draft"]);
+});
+
+test("auditPull treats empty files and unknown behindMain as unknown, not clean", () => {
+  const empty = auditPull(
+    { title: "feat", body: "ok", author: "m", draft: false, headSha: "abc", files: [], behindMain: 0 },
+    "d",
+  );
+  assert.ok(empty.findings.some((finding) => finding.includes("files empty")));
+  const unknownBehind = auditPull(
+    { title: "feat", body: "ok", author: "m", draft: false, headSha: "abc", files: ["src/a.ts"], behindMain: -1 },
+    "d",
+  );
+  assert.ok(unknownBehind.findings.some((finding) => finding.includes("behindMain unknown")));
 });
 
 test("audit never approves or merges", async () => {

--- a/agents/src/policy.ts
+++ b/agents/src/policy.ts
@@ -197,9 +197,25 @@ export function verifyTerrariumReceipt(expected: { runId: string; taskFingerprin
     && got.taskContractStatus !== "unproven";
 }
 
+export const KNOWN_ISSUE_LABELS = ["bug", "docs", "triage:draft", "triage:dig", "triage:spray", "triage:needs-human", "needs-owner-video"] as const;
+
+export function usableIssueLabels(labels: string[]): string[] {
+  const known = new Set<string>(KNOWN_ISSUE_LABELS);
+  return labels.filter((label) => known.has(label));
+}
+
 export function auditPull(input: PullInput, promptDigest: string): AuditReceipt {
   const findings: string[] = [];
-  if (input.behindMain > 0) findings.push(`behind main by ${input.behindMain} commits; rebase before land`);
+  if (!Number.isFinite(input.behindMain) || input.behindMain < 0) {
+    findings.push("behindMain unknown; do not treat this receipt as a rebase check");
+  } else if (input.behindMain > 0) {
+    findings.push(`behind main by ${input.behindMain} commits; rebase before land`);
+  }
+  if (!Array.isArray(input.files)) {
+    findings.push("files unknown; do not treat this receipt as a file-scope check");
+  } else if (input.files.length === 0) {
+    findings.push("files empty or unknown; do not treat this receipt as a file-scope check");
+  }
   if (isSpray({ title: input.title, body: input.body, author: input.author })) {
     return {
       headSha: input.headSha,

--- a/agents/src/ports.ts
+++ b/agents/src/ports.ts
@@ -1,4 +1,4 @@
-import { assertNoMergeAction, type TerrariumReceipt } from "./policy";
+import { assertNoMergeAction, usableIssueLabels, type TerrariumReceipt } from "./policy";
 import type { GithubPort, TerrariumPort } from "./orchestrate";
 import type { AgentsEnv } from "./workflows";
 
@@ -25,15 +25,24 @@ export function liveGithubPort(env: AgentsEnv & { GITHUB_TOKEN?: string; GITHUB_
   return {
     async labelIssue(number, labels) {
       assertNoMergeAction("label");
-      const listed = await gh("/labels?per_page=100");
-      const known = new Set((Array.isArray(listed) ? listed : []).map((row) => String((row as { name?: string }).name || "")));
-      const usable = labels.filter((label) => known.has(label));
+      const usable = usableIssueLabels(labels);
       if (!usable.length) return;
       await gh(`/issues/${number}/labels`, { method: "POST", body: JSON.stringify({ labels: usable }) });
     },
     async comment(number, body) {
       assertNoMergeAction("comment");
       await gh(`/issues/${number}/comments`, { method: "POST", body: JSON.stringify({ body }) });
+    },
+    async listPullFiles(number) {
+      assertNoMergeAction("listPullFiles");
+      const json = await gh(`/pulls/${number}/files?per_page=100`);
+      return (Array.isArray(json) ? json : []).map((row) => String((row as { filename?: string }).filename || "")).filter(Boolean);
+    },
+    async commitsBehindMain(headSha) {
+      assertNoMergeAction("commitsBehindMain");
+      const json = await gh(`/compare/main...${encodeURIComponent(headSha)}`);
+      const behind = Number((json as { behind_by?: number }).behind_by);
+      return Number.isFinite(behind) && behind >= 0 ? behind : -1;
     },
     async openReadyPr(input) {
       assertNoMergeAction("openReadyPr");

--- a/agents/src/worker.ts
+++ b/agents/src/worker.ts
@@ -66,8 +66,6 @@ export default {
             author: String(pr.user?.login || "unknown"),
             draft: Boolean(pr.draft),
             headSha: String(pr.head?.sha || ""),
-            files: [],
-            behindMain: 0,
           },
         });
         return Response.json({ queued: "audit", pr: pr.number, instance: created.id });

--- a/agents/src/workflow-entry.ts
+++ b/agents/src/workflow-entry.ts
@@ -12,8 +12,16 @@ export class TriageWorkflow extends WorkflowEntrypoint<AgentsEnv, IssueInput> {
 
 export class AuditWorkflow extends WorkflowEntrypoint<AgentsEnv, PullInput> {
   async run(event: WorkflowEvent<PullInput>, step: WorkflowStep) {
-    return step.do("audit", () => executeAuditWorkflow(this.env, event.payload, {
-      github: liveGithubPort(this.env),
+    const github = liveGithubPort(this.env);
+    const payload = event.payload;
+    const files = payload.number && github.listPullFiles
+      ? await step.do("files", () => github.listPullFiles!(payload.number!))
+      : [];
+    const behindMain = payload.headSha && github.commitsBehindMain
+      ? await step.do("behind", () => github.commitsBehindMain!(payload.headSha))
+      : -1;
+    return step.do("audit", () => executeAuditWorkflow(this.env, { ...payload, files, behindMain }, {
+      github,
       promptDigest: "agents/audit@live",
     }));
   }

--- a/src/desk-board.test.ts
+++ b/src/desk-board.test.ts
@@ -36,6 +36,17 @@ test("parseDeskBoard fails closed on junk", () => {
   assert.equal(parseDeskBoard({ cards: [{ id: "ok", title: "Keep" }] }).cards[0]?.id, "ok");
 });
 
+test("desk status keeps known values and falls back to pending", () => {
+  const approved = upsertDeskCard(emptyDeskBoard(), { id: "a", title: "a", status: "approved" });
+  const rejected = upsertDeskCard(emptyDeskBoard(), { id: "r", title: "r", status: "rejected" });
+  const unknown = upsertDeskCard(emptyDeskBoard(), { id: "u", title: "u", status: "ship-it" });
+  const nonString = upsertDeskCard(emptyDeskBoard(), { id: "n", title: "n", status: 1 });
+  assert.equal(approved.cards[0]?.status, "approved");
+  assert.equal(rejected.cards[0]?.status, "rejected");
+  assert.equal(unknown.cards[0]?.status, "pending");
+  assert.equal(nonString.cards[0]?.status, "pending");
+});
+
 test("scheme-relative and overlong hrefs are rejected; github.com is kept", () => {
   const scheme = upsertDeskCard(emptyDeskBoard(), { id: "sr", title: "sr", decisionHref: "//evil.example/x" });
   assert.equal(scheme.cards[0]?.decisionHref, null);


### PR DESCRIPTION
Closes #44
Closes #45
Closes #46

## Why

Three filed findings, three small fixes.

- Audit receipts treated empty `files` and `behindMain: 0` as clean. They now fetch files/behind from GitHub, and empty/unknown is a finding.
- `labelIssue` listed every repo label before each write. It now filters against a static allowlist and POSTs once.
- Desk `status` had no tests. Approved/rejected/unknown/non-string are covered.

## Files

See the Files changed tab.

## Proof

```sh
npx tsx --test src/desk-board.test.ts agents/src/policy.test.ts agents/src/harness.test.ts agents/src/github-hmac.test.ts
```

24/24 pass locally.

Overnight hunt rules live in `agents/HUNT.md`: one new issue per tick, no PRs, no merge.
