### PR TITLE
test: www.github.com desk hrefs are untested

### DIFF
--- a/src/desk-board.test.ts
+++ b/src/desk-board.test.ts
@@ -54,4 +54,6 @@ test("scheme-relative and overlong hrefs are rejected; github.com is kept", () =
   assert.equal(overlong.cards[0]?.href, null);
   const github = upsertDeskCard(emptyDeskBoard(), { id: "gh", title: "gh", href: "https://github.com/acoyfellow/my-ax/issues/1" });
   assert.equal(github.cards[0]?.href, "https://github.com/acoyfellow/my-ax/issues/1");
+  const www = upsertDeskCard(emptyDeskBoard(), { id: "www", title: "www", href: "https://www.github.com/acoyfellow/my-ax/issues/1" });
+  assert.equal(www.cards[0]?.href, "https://www.github.com/acoyfellow/my-ax/issues/1");
 });


### PR DESCRIPTION
Closes #49

## Why
Opted-in draft PR.

## Receipt
- issue: https://github.com/acoyfellow/my-ax/issues/49
- kind: bug
- severity: p2
- labels: bug, triage:draft
- visual: public-web

## Files
See the Files changed tab on this PR. This body does not invent a file list.

## Proof
```sh
npx tsx --test src/desk-board.test.ts agents/src/policy.test.ts agents/src/harness.test.ts agents/src/github-hmac.test.ts
```

Worker never merges. Worker never approves. Human merge only.