### PR TITLE
feat: loop board on every triage

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -17,6 +17,8 @@ GitHub cannot do Access. Do not put the gateway Worker on `workers.dev` and do n
 
 `triage:draft` is an opt-in for a **ready** GitHub PR (`draft: false`), not a GitHub draft. The method is `openReadyPr`. The head is `bot/issue-<n>`. The body uses `Closes #<n>` and does not invent a file list.
 
+Every triage comment is a **loop board**: `stage` is `labeled`, `blocked-missing-branch`, `pr-opened`, or `pr-failed`. If the head branch is missing, the board says so. Worker never merges.
+
 Hunt ticks that only file issues: [HUNT.md](./HUNT.md).
 
 Model: `AGENTS_MODEL` (default `grok-4.6`). Inference only through employee-injected `LLM_GATEWAY_URL` + `LLM_GATEWAY_TOKEN`.

--- a/agents/src/orchestrate.ts
+++ b/agents/src/orchestrate.ts
@@ -20,6 +20,7 @@ export interface GithubPort {
   openReadyPr(input: { title: string; body: string; head: string }): Promise<{ number: number }>;
   listPullFiles?(number: number): Promise<string[]>;
   commitsBehindMain?(headSha: string): Promise<number>;
+  hasBranch?(name: string): Promise<boolean>;
   mergePr(number: number): Promise<void>;
   approvePr(number: number): Promise<void>;
 }
@@ -43,17 +44,49 @@ export type TriageStep =
   | { step: "visual"; accepted: boolean }
   | { step: "stop"; reason: string };
 
+export function formatLoopBoard(input: {
+  issueNumber: number;
+  classification: Classification;
+  modelId: string;
+  stage: "labeled" | "blocked-missing-branch" | "pr-opened" | "pr-failed";
+  prNumber?: number;
+  error?: string;
+}): string {
+  const issue = `https://github.com/acoyfellow/my-ax/issues/${input.issueNumber}`;
+  const head = `bot/issue-${input.issueNumber}`;
+  const lines = [
+    "## loop board",
+    `issue: ${issue}`,
+    `stage: ${input.stage}`,
+    `kind: ${input.classification.kind}`,
+    `labels: ${input.classification.labels.join(", ") || "none"}`,
+    `head: ${head}`,
+    `model: ${input.modelId}`,
+  ];
+  if (input.prNumber) lines.push(`pr: https://github.com/acoyfellow/my-ax/pull/${input.prNumber}`);
+  if (input.stage === "blocked-missing-branch") {
+    lines.push(`blocked: push ${head} then comment triage:draft again, or add triage:draft before opening.`);
+  }
+  if (input.stage === "labeled" && !input.classification.draft) {
+    lines.push("next: add triage:draft and a matching head branch if you want a ready PR. Worker never merges.");
+  }
+  if (input.error) lines.push(`error: ${input.error}`);
+  return lines.join("\n");
+}
+
 export async function runTriage(input: IssueInput, ports: { github: GithubPort; terrarium: TerrariumPort; model: ModelPort }): Promise<TriageStep[]> {
   const classification = ports.model.classify ? await ports.model.classify(input) : classifyIssue(input);
   const steps: TriageStep[] = [{ step: "classify", classification }];
   const issueNumber = input.number ?? 0;
-  await ports.github.comment(issueNumber, `${classification.summary}\nmodel=${ports.model.modelId}`);
-  steps.push({ step: "comment" });
+  let stage: "labeled" | "blocked-missing-branch" | "pr-opened" | "pr-failed" = "labeled";
+  let prNumber: number | undefined;
+  let error: string | undefined;
   try {
     await ports.github.labelIssue(issueNumber, classification.labels);
     steps.push({ step: "label", labels: classification.labels });
   } catch {
-    steps.push({ step: "stop", reason: "label failed; comment posted" });
+    steps.push({ step: "stop", reason: "label failed" });
+    error = "label failed";
   }
   if (shouldSpawnDig(classification)) {
     const contract = await ports.terrarium.spawn(`Hard issue: ${input.title}\n${input.body}`);
@@ -62,30 +95,51 @@ export async function runTriage(input: IssueInput, ports: { github: GithubPort; 
     steps.push({ step: "dig", runId: contract.runId, verified });
     if (!verified) {
       steps.push({ step: "stop", reason: "terrarium receipt unproven" });
+      await ports.github.comment(issueNumber, formatLoopBoard({
+        issueNumber, classification, modelId: ports.model.modelId, stage: "labeled", error: "terrarium receipt unproven",
+      }));
+      steps.push({ step: "comment" });
       return steps;
     }
     const visualOk = acceptVisualProof(classification.visual, receipt.visual);
     steps.push({ step: "visual", accepted: visualOk });
     if (!visualOk) {
       steps.push({ step: "stop", reason: "visual proof missing" });
+      await ports.github.comment(issueNumber, formatLoopBoard({
+        issueNumber, classification, modelId: ports.model.modelId, stage: "labeled", error: "visual proof missing",
+      }));
+      steps.push({ step: "comment" });
       return steps;
     }
-    return steps;
-  }
-  if (shouldOpenDraft(classification)) {
-    if (!input.number) {
-      steps.push({ step: "stop", reason: "issue number required before opening a PR" });
-      return steps;
+  } else if (shouldOpenDraft(classification) && issueNumber) {
+    const head = `bot/issue-${issueNumber}`;
+    const exists = ports.github.hasBranch ? await ports.github.hasBranch(head) : true;
+    if (!exists) {
+      stage = "blocked-missing-branch";
+      steps.push({ step: "stop", reason: `missing ${head}` });
+    } else {
+      try {
+        const pr = await ports.github.openReadyPr({
+          title: formatReadyPrTitle(input),
+          body: formatReadyPrBody(input, classification),
+          head,
+        });
+        prNumber = pr.number;
+        stage = "pr-opened";
+        steps.push({ step: "pr", number: pr.number });
+      } catch (err) {
+        stage = "pr-failed";
+        error = err instanceof Error ? err.message : String(err);
+        steps.push({ step: "stop", reason: error });
+      }
     }
-    const pr = await ports.github.openReadyPr({
-      title: formatReadyPrTitle(input),
-      body: formatReadyPrBody(input, classification),
-      head: `bot/issue-${input.number}`,
-    });
-    steps.push({ step: "pr", number: pr.number });
-    return steps;
+  } else {
+    steps.push({ step: "stop", reason: classification.spray ? "spray" : "no-draft" });
   }
-  steps.push({ step: "stop", reason: classification.spray ? "spray" : "no-draft" });
+  await ports.github.comment(issueNumber, formatLoopBoard({
+    issueNumber, classification, modelId: ports.model.modelId, stage, prNumber, error,
+  }));
+  steps.push({ step: "comment" });
   return steps;
 }
 

--- a/agents/src/policy.test.ts
+++ b/agents/src/policy.test.ts
@@ -12,7 +12,7 @@ import {
   usableIssueLabels,
   verifyTerrariumReceipt,
 } from "./policy";
-import { PROOF_COMMAND, formatReadyPrBody, formatReadyPrTitle, runAudit, runTriage, type GithubPort, type TerrariumPort } from "./orchestrate";
+import { PROOF_COMMAND, formatLoopBoard, formatReadyPrBody, formatReadyPrTitle, runAudit, runTriage, type GithubPort, type TerrariumPort } from "./orchestrate";
 import { executeTriageWorkflow } from "./workflows";
 
 function memoryGithub(): GithubPort & { actions: string[] } {
@@ -22,6 +22,7 @@ function memoryGithub(): GithubPort & { actions: string[] } {
     async labelIssue(_n, labels) { actions.push(`label:${labels.join(",")}`); },
     async comment() { actions.push("comment"); },
     async openReadyPr(input) { actions.push(`pr:${input.title}`); actions.push(`head:${input.head}`); actions.push(`body:${input.body}`); return { number: 7 }; },
+    async hasBranch(name) { actions.push(`hasBranch:${name}`); return name === "bot/issue-40"; },
     async mergePr() { actions.push("merge"); },
     async approvePr() { actions.push("approve"); },
   };
@@ -38,6 +39,14 @@ test("AGENTS_MODEL defaults to grok-4.6 and is overridable", () => {
   assert.equal(DEFAULT_AGENTS_MODEL, "grok-4.6");
   assert.equal(resolveAgentsModel({}), "grok-4.6");
   assert.equal(resolveAgentsModel({ AGENTS_MODEL: "kimi-k2.7" }), "kimi-k2.7");
+});
+
+test("loop board names stage and next action", () => {
+  const classification = classifyIssue({ title: "bug: x", body: "repro", author: "o" });
+  const text = formatLoopBoard({ issueNumber: 52, classification, modelId: "grok-4.6", stage: "labeled" });
+  assert.match(text, /stage: labeled/);
+  assert.match(text, /issues\/52/);
+  assert.match(text, /triage:draft/);
 });
 
 test("ready PR body names the issue, proof command, and never-merge rule", () => {

--- a/agents/src/ports.ts
+++ b/agents/src/ports.ts
@@ -33,6 +33,15 @@ export function liveGithubPort(env: AgentsEnv & { GITHUB_TOKEN?: string; GITHUB_
       assertNoMergeAction("comment");
       await gh(`/issues/${number}/comments`, { method: "POST", body: JSON.stringify({ body }) });
     },
+    async hasBranch(name) {
+      assertNoMergeAction("hasBranch");
+      try {
+        await gh(`/git/ref/heads/${encodeURIComponent(name)}`);
+        return true;
+      } catch {
+        return false;
+      }
+    },
     async listPullFiles(number) {
       assertNoMergeAction("listPullFiles");
       const json = await gh(`/pulls/${number}/files?per_page=100`);


### PR DESCRIPTION
## Why

#52–#54 were labeled and then went silent. The Worker said “draft only with triage:draft” and stopped. There was no board: no stage, no missing-branch, no PR URL.

This change posts a **loop board** on every triage:

```
stage: labeled | blocked-missing-branch | pr-opened | pr-failed
issue: …
head: bot/issue-<n>
pr: …   (only when opened)
```

If the head branch is missing, the comment says so. Worker still never merges.

## Proof

```sh
npx tsx --test agents/src/policy.test.ts agents/src/harness.test.ts agents/src/github-hmac.test.ts src/desk-board.test.ts
```

25/25 locally.
