### PR TITLE
fix: turn paints Invalid URL string as three Error bubbles

### DIFF
--- a/src/ui/owner-error.test.ts
+++ b/src/ui/owner-error.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { clarifyOwnerError } from "./owner-error";
+
+test("Invalid URL string becomes one owner sentence", () => {
+  assert.equal(
+    clarifyOwnerError("Invalid URL string."),
+    "A link on this turn is not a valid URL. The turn stopped. Check desk or notify hrefs.",
+  );
+});
+
+test("other errors stay as written", () => {
+  assert.equal(clarifyOwnerError("Image upload failed"), "Image upload failed");
+});

--- a/src/ui/owner-error.ts
+++ b/src/ui/owner-error.ts
@@ -1,0 +1,6 @@
+export function clarifyOwnerError(text: string): string {
+  if (/invalid url string/i.test(text)) {
+    return "A link on this turn is not a valid URL. The turn stopped. Check desk or notify hrefs.";
+  }
+  return text;
+}

--- a/src/ui/store.svelte.ts
+++ b/src/ui/store.svelte.ts
@@ -1,3 +1,5 @@
+import { clarifyOwnerError } from "./owner-error";
+
 // Shared Svelte 5 store for my-ax.
 //
 // .svelte.ts modules can use $state/$derived runes at module scope. Every
@@ -177,9 +179,11 @@ export function pushSystem(text: string) {
   ];
 }
 export function pushError(text: string) {
+  const next = clarifyOwnerError(text);
+  if (toastBus.pending.some((toast) => toast.kind === "error" && toast.text === next)) return;
   toastBus.pending = [
     ...toastBus.pending,
-    { id: `toast-${++toastCounter}`, kind: "error", text },
+    { id: `toast-${++toastCounter}`, kind: "error", text: next },
   ];
 }
 export function clearToast(id: string) {


### PR DESCRIPTION
Closes #53

## Why
Opted-in draft PR.

## Receipt
- issue: https://github.com/acoyfellow/my-ax/issues/53
- kind: bug
- severity: p2
- labels: bug, triage:draft
- visual: owner-device

## Files
See the Files changed tab on this PR. This body does not invent a file list.

## Proof
```sh
npx tsx --test src/desk-board.test.ts agents/src/policy.test.ts agents/src/harness.test.ts agents/src/github-hmac.test.ts
```

Worker never merges. Worker never approves. Human merge only.