### PR TITLE
fix: keep leftover DeskHub class so apex deploy can ship

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -60,7 +60,7 @@ import { scanDeadSessions } from "./dead-session";
 export { MyAgent } from "./agent";
 export { ReadOnlyDelegateAgent } from "./delegate-many";
 export { VoiceThinkAgent } from "./voice-think-agent";
-export { UserAgent } from "./user-agent";
+export { UserAgent, DeskHub } from "./user-agent";
 export { OAuthClientDO } from "./oauth-store";
 export { MachineHost } from "./machinectl-host";
 export { Sandbox } from "@cloudflare/sandbox";

--- a/src/user-agent.ts
+++ b/src/user-agent.ts
@@ -8,3 +8,5 @@ import { Agent } from "agents";
 import type { Env } from "./types";
 
 export class UserAgent extends Agent<Env> {}
+
+export class DeskHub extends Agent<Env> {}


### PR DESCRIPTION
Live script still depends on DeskHub. A delete-class tag fails dry-run because the public chain never created DeskHub.

Export a leftover DeskHub class. Keep the v12-desk-hub no-op tag so wrangler finds the live tag.

Proof: wrangler deploy --dry-run succeeds; live deploy no longer reports DeskHub missing.