### PR TITLE
fix: main typecheck fails on UserAgent broadcast

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -173,6 +173,10 @@ export class MyAgent extends Think<Env> {
   // TurnConfig.chatStreamStallTimeoutMs for turns with known-slow tools.
   override chatStreamStallTimeoutMs = 300_000;
 
+  sendDeskBoard(frame: string): void {
+    this.broadcast(frame);
+  }
+
   /** Per-turn flag: set when a successful tool call may have written under
    *  /home/user. Drives a single snapshotUserWorkspace() in onChatResponse.
    *  Reset at the start of every turn via onChatResponse itself (after we

--- a/src/error-issue.ts
+++ b/src/error-issue.ts
@@ -7,8 +7,6 @@ import {
   type ErrorReportInput,
   type FiledErrorIssue,
 } from "./error-report";
-import { ownerDeskUpsert } from "./routes/desk";
-
 const ISSUE_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 interface GithubIssueResult {
@@ -37,13 +35,13 @@ export async function fileOwnerErrorIssue(
   }
   const created = await createGithubIssue(token, repo, input, fingerprint, post);
   await rememberFingerprint(env, ownerEmail, fingerprint, created).catch(() => undefined);
-  await ownerDeskUpsert(env, ownerEmail, {
+  await import("./routes/desk").then((mod) => mod.ownerDeskUpsert(env, ownerEmail, {
     id: `error-${fingerprint}`,
     title: formatAutoIssueTitle(input),
     body: `${input.origin} ${input.message}`.slice(0, 800),
     href: created.html_url,
     status: "pending",
-  }).catch(() => undefined);
+  })).catch(() => undefined);
   return { number: created.number, url: created.html_url, fingerprint, created: true };
 }
 

--- a/src/user-agent.ts
+++ b/src/user-agent.ts
@@ -16,7 +16,7 @@ export class UserAgent extends Agent<Env> {
     for (const sessionId of sessionIds) {
       if (!sessionId) continue;
       const facet = await getSubAgentByName(this, MyAgent, sessionId);
-      facet.broadcast(frame);
+      await facet.sendDeskBoard(frame);
     }
   }
 }


### PR DESCRIPTION
Closes #79

## Why
Opted-in draft PR.

## Receipt
- issue: https://github.com/acoyfellow/my-ax/issues/79
- kind: bug
- severity: p2
- labels: bug, triage:draft
- visual: none

## Files
See the Files changed tab on this PR. This body does not invent a file list.

## Proof
```sh
npx tsx --test src/desk-board.test.ts agents/src/policy.test.ts agents/src/harness.test.ts agents/src/github-hmac.test.ts
```

Worker never merges. Worker never approves. Human merge only.