### PR TITLE
fix: labeled issues sit after the loop board

### DIFF
--- a/agents/src/sweep.test.ts
+++ b/agents/src/sweep.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { extractFingerprint, formatDuplicateClose, hasLoopBoard, planSweep, SWEEP_MAX_CLOSES, SWEEP_MAX_QUEUES } from "./sweep";
+import { extractFingerprint, formatDuplicateClose, formatParkClose, hasLoopBoard, planSweep, SWEEP_MAX_CLOSES, SWEEP_MAX_QUEUES } from "./sweep";
 
 test("same fingerprint keeps the lowest number and closes the rest", () => {
   const actions = planSweep([
@@ -12,6 +12,7 @@ test("same fingerprint keeps the lowest number and closes the rest", () => {
     { action: "keep", number: 67, fingerprint: "e8a37db7f3311f4b" },
     { action: "close-duplicate", number: 69, keep: 67, fingerprint: "e8a37db7f3311f4b" },
     { action: "close-duplicate", number: 68, keep: 67, fingerprint: "e8a37db7f3311f4b" },
+    { action: "park", number: 67 },
   ]);
 });
 
@@ -22,6 +23,34 @@ test("issues without a loop board are queued once", () => {
   ]);
   assert.ok(actions.some((row) => row.action === "queue" && row.number === 74));
   assert.ok(!actions.some((row) => row.action === "queue" && row.number === 75));
+  assert.ok(actions.some((row) => row.action === "park" && row.number === 75));
+});
+
+test("labeled issues without a head or opt-in are parked", () => {
+  const actions = planSweep([
+    { number: 67, title: "bug: image", body: "fingerprint: `e8a37db7f3311f4b`", author: "o", state: "open", comments: ["## loop board\nstage: labeled"], hasHead: false },
+    { number: 76, title: "bug: heal", body: "repro", author: "o", state: "open", comments: ["## loop board\nstage: labeled"], hasHead: false },
+  ]);
+  assert.ok(actions.some((row) => row.action === "park" && row.number === 67));
+  assert.ok(actions.some((row) => row.action === "park" && row.number === 76));
+  assert.ok(!actions.some((row) => row.action === "queue"));
+});
+
+test("opted-in labeled issues with a head are queued again", () => {
+  const actions = planSweep([
+    {
+      number: 83,
+      title: "bug: labeled issues sit after the loop board",
+      body: "receipt",
+      author: "o",
+      state: "open",
+      comments: ["## loop board\nstage: labeled", "triage:draft"],
+      hasHead: true,
+    },
+  ]);
+  assert.deepEqual(actions.filter((row) => row.action === "queue" || row.action === "park"), [
+    { action: "queue", number: 83 },
+  ]);
 });
 
 test("sweep caps closes and queues", () => {
@@ -42,6 +71,13 @@ test("duplicate close text is public and names the keeper", () => {
   const body = formatDuplicateClose(67, "e8a37db7f3311f4b");
   assert.match(body, /#67/);
   assert.match(body, /e8a37db7f3311f4b/);
+  assert.doesNotMatch(body, /employee|my-ax-private|hooks\.ax/);
+});
+
+test("park close text names the head and how to promote", () => {
+  const body = formatParkClose(67);
+  assert.match(body, /bot\/issue-67/);
+  assert.match(body, /triage:draft/);
   assert.doesNotMatch(body, /employee|my-ax-private|hooks\.ax/);
 });
 

--- a/agents/src/sweep.ts
+++ b/agents/src/sweep.ts
@@ -12,12 +12,14 @@ export interface SweepIssue {
   author: string;
   state: "open" | "closed";
   comments: string[];
+  hasHead?: boolean;
 }
 
 export type SweepAction =
   | { action: "keep"; number: number; fingerprint: string }
   | { action: "close-duplicate"; number: number; keep: number; fingerprint: string }
-  | { action: "queue"; number: number };
+  | { action: "queue"; number: number }
+  | { action: "park"; number: number };
 
 export function extractFingerprint(body: string): string | null {
   const match = body.match(FINGERPRINT_RE);
@@ -26,6 +28,11 @@ export function extractFingerprint(body: string): string | null {
 
 export function hasLoopBoard(comments: string[]): boolean {
   return comments.some((body) => LOOP_BOARD_RE.test(body));
+}
+
+export function hasTriageDraft(comments: string[], body: string): boolean {
+  if (/\btriage:draft\b/i.test(body)) return true;
+  return comments.some((text) => /\btriage:draft\b/i.test(text) && !LOOP_BOARD_RE.test(text));
 }
 
 export function planSweep(issues: SweepIssue[]): SweepAction[] {
@@ -54,11 +61,26 @@ export function planSweep(issues: SweepIssue[]): SweepAction[] {
     }
   }
 
+  const closing = new Set(actions.filter((row) => row.action === "close-duplicate").map((row) => row.number));
   for (const issue of open) {
-    if (hasLoopBoard(issue.comments)) continue;
-    if (queues >= SWEEP_MAX_QUEUES) break;
-    actions.push({ action: "queue", number: issue.number });
-    queues += 1;
+    if (closing.has(issue.number)) continue;
+    const boarded = hasLoopBoard(issue.comments);
+    const opted = hasTriageDraft(issue.comments, issue.body);
+    if (!boarded) {
+      if (queues >= SWEEP_MAX_QUEUES) continue;
+      actions.push({ action: "queue", number: issue.number });
+      queues += 1;
+      continue;
+    }
+    if (opted && issue.hasHead) {
+      if (queues >= SWEEP_MAX_QUEUES) continue;
+      actions.push({ action: "queue", number: issue.number });
+      queues += 1;
+      continue;
+    }
+    if (closes >= SWEEP_MAX_CLOSES) continue;
+    actions.push({ action: "park", number: issue.number });
+    closes += 1;
   }
 
   return actions;
@@ -70,5 +92,13 @@ export function formatDuplicateClose(keep: number, fingerprint: string): string 
     `fingerprint: \`${fingerprint}\``,
     `keep: #${keep}`,
     "Closing this as a duplicate.",
+  ].join("\n");
+}
+
+export function formatParkClose(number: number): string {
+  return [
+    "Labeled with no head or no triage:draft after a sweep.",
+    `head: bot/issue-${number}`,
+    "Closing as parked. Reopen with a head branch and triage:draft to promote.",
   ].join("\n");
 }

--- a/agents/src/worker.ts
+++ b/agents/src/worker.ts
@@ -1,7 +1,7 @@
 import { forwardedFromHook, workflowBindings, type AgentsEnv } from "./workflows";
 import { verifyGithubSignature } from "./github-hmac";
 import { liveGithubPort } from "./ports";
-import { formatDuplicateClose, planSweep, type SweepIssue } from "./sweep";
+import { formatDuplicateClose, formatParkClose, planSweep, type SweepIssue } from "./sweep";
 
 export { AuditWorkflow, DigWorkflow, ReviewWorkflow, TriageWorkflow } from "./workflow-entry";
 
@@ -120,7 +120,8 @@ export async function runIssueSweep(env: WorkerEnv): Promise<{ closed: number; q
   const issues: SweepIssue[] = [];
   for (const issue of open) {
     const comments = await github.listComments(issue.number);
-    issues.push({ ...issue, state: "open", comments });
+    const hasHead = github.hasBranch ? await github.hasBranch(`bot/issue-${issue.number}`) : false;
+    issues.push({ ...issue, state: "open", comments, hasHead });
   }
   const actions = planSweep(issues);
   let closed = 0;
@@ -128,6 +129,10 @@ export async function runIssueSweep(env: WorkerEnv): Promise<{ closed: number; q
   for (const action of actions) {
     if (action.action === "close-duplicate" && github.closeIssue) {
       await github.closeIssue(action.number, formatDuplicateClose(action.keep, action.fingerprint));
+      closed += 1;
+    }
+    if (action.action === "park" && github.closeIssue) {
+      await github.closeIssue(action.number, formatParkClose(action.number));
       closed += 1;
     }
     if (action.action === "queue") {


### PR DESCRIPTION
Closes #83

## Why
Opted-in draft PR.

## Receipt
- issue: https://github.com/acoyfellow/my-ax/issues/83
- kind: bug
- severity: p2
- labels: bug, triage:draft
- visual: none

## Files
See the Files changed tab on this PR. This body does not invent a file list.

## Proof
```sh
npx tsx --test src/desk-board.test.ts agents/src/policy.test.ts agents/src/harness.test.ts agents/src/github-hmac.test.ts
```

Worker never merges. Worker never approves. Human merge only.