### PR TITLE
fix: Browser Run replay cards 404 instead of falling back to durable screenshots

### DIFF
--- a/src/browser-tools.ts
+++ b/src/browser-tools.ts
@@ -66,11 +66,17 @@ export function createMyAxBrowserTools(env: Env, identity?: () => AccessIdentity
           // assets. Preserve the originally rendered viewport as an owned R2
           // raster artifact so the tool card always has durable visual proof.
           let screenshotSrc: string | undefined;
+          let replayUrl: string | undefined;
           const owner = identity?.();
           const ownerSession = ownerSessionId?.();
           if (owner && ownerSession) {
-            await env.DB.prepare("INSERT OR REPLACE INTO browser_recordings(id, owner_email, session_id, created_at) VALUES (?, ?, ?, datetime('now'))")
-              .bind(sessionId, owner.email.toLowerCase(), ownerSession).run();
+            try {
+              await env.DB.prepare("INSERT OR REPLACE INTO browser_recordings(id, owner_email, session_id, created_at) VALUES (?, ?, ?, datetime('now'))")
+                .bind(sessionId, owner.email.toLowerCase(), ownerSession).run();
+              replayUrl = `/browser/replay/${encodeURIComponent(sessionId)}`;
+            } catch {
+              replayUrl = undefined;
+            }
           }
           if (owner) {
             try {
@@ -106,7 +112,7 @@ export function createMyAxBrowserTools(env: Env, identity?: () => AccessIdentity
             recordingFormat: "rrweb",
             note: "Recorded by Cloudflare Browser Run with harmless inspection pointer movement and scroll so inline playback has visible motion and a scrub-able timeline.",
             replayMotion: "inspection-scroll",
-            replayUrl: `/browser/replay/${encodeURIComponent(sessionId)}`,
+            replayUrl,
             screenshotSrc,
           };
         } catch (error) {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -343,6 +343,18 @@
   background: #0b0d12;
 }
 
+.browser-replay-unavailable {
+  display: block;
+  width: 100%;
+  margin-top: 8px;
+  padding: 10px 12px;
+  border: 1px solid var(--color-line);
+  border-radius: 6px;
+  background: var(--color-surface-2, #111a24);
+  color: var(--color-fg-mut);
+  font-size: 0.8rem;
+}
+
 /* Audio Messages: inline TTS clip player, rendered like an artifact card. */
 .audio-message {
   display: flex;

--- a/src/ui/ToolResultWidget.svelte
+++ b/src/ui/ToolResultWidget.svelte
@@ -10,6 +10,7 @@
   // .mov in some browsers) flips to a direct-open link instead of a silent
   // broken/blank player. Keyed by src so multiple widgets don't clobber.
   let mediaError = $state<Record<string, boolean>>({});
+  let replayFailed = $state(false);
   let reusableToolAction = $state<"idle" | "approving" | "enabled" | "error">("idle");
   let reusableToolMessage = $state("");
 
@@ -61,6 +62,17 @@
     return () => {
       document.body.style.overflow = prev;
     };
+  });
+
+  $effect(() => {
+    const href = widget.kind === "browser-run" ? widget.recordingHref : undefined;
+    if (!href) { replayFailed = false; return; }
+    replayFailed = false;
+    let cancelled = false;
+    fetch(href, { credentials: "include", headers: { accept: "application/json" } })
+      .then((response) => { if (!cancelled && !response.ok) replayFailed = true; })
+      .catch(() => { if (!cancelled) replayFailed = true; });
+    return () => { cancelled = true; };
   });
 </script>
 
@@ -144,7 +156,7 @@
       data-tool-widget="browser-run-screenshot"
     />
   {/if}
-  {#if widget.replaySrc}
+  {#if widget.replaySrc && !replayFailed}
     <iframe
       class="browser-replay-frame"
       src={widget.replaySrc}
@@ -152,6 +164,8 @@
       loading="lazy"
       referrerpolicy="no-referrer"
     ></iframe>
+  {:else if widget.replaySrc && replayFailed}
+    <span class="browser-replay-unavailable" data-tool-widget="browser-run-replay-unavailable">Replay unavailable — showing captured screenshot.</span>
   {/if}
 {:else if widget.kind === "inline-raster-image"}
   {#if mediaError[widget.src]}

--- a/src/ui/browser-replay-fallback-proof.mjs
+++ b/src/ui/browser-replay-fallback-proof.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+
+import { build } from "esbuild";
+import sveltePlugin from "esbuild-svelte";
+import { createServer } from "node:http";
+import { mkdtempSync, mkdirSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const uiDir = dirname(fileURLToPath(import.meta.url));
+const widget = resolve(uiDir, "ToolResultWidget.svelte");
+const work = mkdtempSync(join(tmpdir(), "myax-replay-proof-"));
+const outDir = process.env.REPLAY_PROOF_OUT ?? join(work, "out");
+mkdirSync(outDir, { recursive: true });
+
+const SCREENSHOT = "/api/artifacts/00000000-0000-4000-8000-000000000000";
+const PORT = 8799;
+
+const entry = join(work, "entry.js");
+writeFileSync(entry, `
+import { mount } from "svelte";
+import ToolResultWidget from ${JSON.stringify(widget)};
+const base = {
+  kind: "browser-run", status: "done", url: "https://example.com",
+  title: "Example page", textPreview: "Rendered text preview from the captured page.",
+  recorded: true, recordingFormat: "rrweb", note: "recorded",
+  screenshotSrc: ${JSON.stringify(SCREENSHOT)},
+};
+for (const [id, replayUrl] of [["bad", "/browser/replay/bad"], ["good", "/browser/replay/good"]]) {
+  mount(ToolResultWidget, {
+    target: document.getElementById(id),
+    props: { result: { ...base, replayUrl }, toolName: "browser_open" },
+  });
+}
+`);
+
+const html = `<!doctype html><meta charset="utf-8">
+<title>Replay fallback proof</title>
+<style>
+  :root { color-scheme: dark; --color-fg:#e8edf5; --color-fg-mut:#9ca9bd; --color-line:#232936; --color-surface-2:#111a24; }
+  body { margin:0; background:#0b0d12; color:var(--color-fg); font:14px system-ui; padding:24px; }
+  h1 { font-size:18px; margin:0 0 6px; } p { color:var(--color-fg-mut); margin:0 0 20px; }
+  section { border:1px solid var(--color-line); border-radius:10px; padding:16px; margin-bottom:24px; background:#0e141b; }
+  h2 { font-size:14px; margin:0 0 10px; }
+  .browser-replay-frame { display:block; width:100%; height:280px; margin-top:8px; border:1px solid var(--color-line); border-radius:6px; background:#0b0d12; }
+  .browser-replay-unavailable { display:block; width:100%; margin-top:8px; padding:10px 12px; border:1px solid var(--color-line); border-radius:6px; background:var(--color-surface-2); color:var(--color-fg-mut); font-size:.8rem; }
+</style>
+<h1>Browser Run replay fallback</h1>
+<p>Same card, two recordings. The fixed card collapses the missing replay to the screenshot.</p>
+<section><h2>Fixed &mdash; recording missing (404)</h2><div id="bad"></div></section>
+<section><h2>Healthy &mdash; recording present (200)</h2><div id="good"></div></section>
+<script type="module" src="/bundle.js"></script>`;
+
+await build({
+  entryPoints: [entry],
+  bundle: true,
+  format: "esm",
+  platform: "browser",
+  absWorkingDir: resolve(uiDir, "..", ".."),
+  nodePaths: [resolve(uiDir, "..", "..", "node_modules")],
+  outfile: join(work, "bundle.js"),
+  plugins: [sveltePlugin({ compileOptions: { generate: "client" } })],
+  logLevel: "error",
+});
+
+const { readFileSync } = await import("node:fs");
+const bundle = readFileSync(join(work, "bundle.js"), "utf8");
+const png = Buffer.from("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==", "base64");
+
+const routes = {
+  "/": [200, "text/html", html],
+  "/index.html": [200, "text/html", html],
+  "/bundle.js": [200, "text/javascript", bundle],
+  "/api/browser/recordings/good": [200, "application/json", JSON.stringify({ ok: true })],
+  "/api/browser/recordings/bad": [404, "application/json", JSON.stringify({ ok: false })],
+  "/browser/replay/good": [200, "text/html", "<body style='background:#0b0d12;color:#e8edf5;font:13px system-ui'>playable replay</body>"],
+  [SCREENSHOT]: [200, "image/png", png],
+};
+
+const server = createServer((req, res) => {
+  const hit = routes[(req.url || "/").split("?")[0]];
+  if (!hit) { res.writeHead(404, { "content-type": "text/plain" }); res.end("not found"); return; }
+  res.writeHead(hit[0], { "content-type": hit[1] });
+  res.end(hit[2]);
+});
+await new Promise((ok) => server.listen(PORT, "127.0.0.1", ok));
+
+let pass = false;
+let results = {};
+try {
+  const { chromium } = await import("playwright");
+  const browser = await chromium.launch();
+  const context = await browser.newContext({
+    viewport: { width: 1000, height: 620 },
+    recordVideo: { dir: join(outDir, "video"), size: { width: 1000, height: 620 } },
+  });
+  const page = await context.newPage();
+  await page.goto(`http://127.0.0.1:${PORT}/index.html`, { waitUntil: "networkidle" });
+  await page.waitForTimeout(1200);
+
+  results = {
+    badCard_replayUnavailableNote: await page.locator('[data-tool-widget="browser-run-replay-unavailable"]').count(),
+    badCard_iframes: await page.locator("#bad iframe.browser-replay-frame").count(),
+    badCard_screenshots: await page.locator("#bad img").count(),
+    goodCard_iframes: await page.locator("#good iframe.browser-replay-frame").count(),
+  };
+
+  await page.locator("#bad").scrollIntoViewIfNeeded();
+  await page.waitForTimeout(900);
+  await page.locator("#good").scrollIntoViewIfNeeded();
+  await page.waitForTimeout(900);
+  await page.screenshot({ path: join(outDir, "replay-fallback.png"), fullPage: true });
+  await context.close();
+  await browser.close();
+
+  const clip = readdirSync(join(outDir, "video")).find((f) => f.endsWith(".webm"));
+  if (clip) renameSync(join(outDir, "video", clip), join(outDir, "replay-fallback.webm"));
+
+  pass = results.badCard_replayUnavailableNote === 1
+    && results.badCard_iframes === 0
+    && results.badCard_screenshots > 0
+    && results.goodCard_iframes === 1;
+} finally {
+  server.close();
+  rmSync(work, { recursive: true, force: true });
+}
+
+console.log(JSON.stringify(results, null, 2));
+console.log(`artifacts: ${outDir}`);
+console.log(pass
+  ? "# pass browser-replay-fallback: missing recording collapses to screenshot; healthy recording keeps its replay"
+  : "# FAIL browser-replay-fallback");
+process.exit(pass ? 0 : 1);

--- a/src/ui/browser-replay-fallback.test.ts
+++ b/src/ui/browser-replay-fallback.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveToolResultWidget } from "./tool-result-widgets";
+
+const browserRun = (extra: Record<string, unknown> = {}) => ({
+  kind: "browser-run",
+  status: "done",
+  url: "https://example.com",
+  title: "Example",
+  textPreview: "hello",
+  recorded: true,
+  recordingFormat: "rrweb",
+  note: "recorded",
+  ...extra,
+});
+
+test("a browser run with screenshot only renders no replay iframe", () => {
+  const widget = resolveToolResultWidget(browserRun({
+    screenshotSrc: "/api/artifacts/00000000-0000-4000-8000-000000000000",
+  }), "browser_open");
+  assert.equal(widget.kind, "browser-run");
+  assert.equal(widget.replaySrc, undefined);
+  assert.ok(widget.screenshotSrc);
+});
+
+test("a browser run with a registered replay keeps both sources", () => {
+  const widget = resolveToolResultWidget(browserRun({
+    replayUrl: "/browser/replay/abc123",
+    screenshotSrc: "/api/artifacts/00000000-0000-4000-8000-000000000000",
+  }), "browser_open");
+  assert.equal(widget.kind, "browser-run");
+  assert.equal(widget.replaySrc, "/browser/replay/abc123?embed=1");
+  assert.ok(widget.screenshotSrc);
+});
+
+test("an external replay url is never embedded", () => {
+  const widget = resolveToolResultWidget(browserRun({
+    replayUrl: "https://evil.example/replay/abc123",
+    screenshotSrc: "/api/artifacts/00000000-0000-4000-8000-000000000000",
+  }), "browser_open");
+  assert.equal(widget.kind, "browser-run");
+  assert.equal(widget.replaySrc, undefined);
+  assert.ok(widget.screenshotSrc);
+});

--- a/src/ui/browser-replay-fallback.test.ts
+++ b/src/ui/browser-replay-fallback.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { resolveToolResultWidget } from "./tool-result-widgets";
+import { browserReplayRecordingHref, resolveToolResultWidget } from "./tool-result-widgets";
 
 const browserRun = (extra: Record<string, unknown> = {}) => ({
   kind: "browser-run",
@@ -41,4 +41,11 @@ test("an external replay url is never embedded", () => {
   assert.equal(widget.kind, "browser-run");
   assert.equal(widget.replaySrc, undefined);
   assert.ok(widget.screenshotSrc);
+});
+
+test("recording href maps an internal replay to the recordings API", () => {
+  assert.equal(browserReplayRecordingHref("/browser/replay/abc123?embed=1"), "/api/browser/recordings/abc123");
+  assert.equal(browserReplayRecordingHref("/browser/replay/abc123"), "/api/browser/recordings/abc123");
+  assert.equal(browserReplayRecordingHref("https://evil.example/replay/abc123"), undefined);
+  assert.equal(browserReplayRecordingHref(undefined), undefined);
 });

--- a/src/ui/tool-result-widgets.ts
+++ b/src/ui/tool-result-widgets.ts
@@ -12,6 +12,12 @@ const INLINE_IMAGE_RE = /^data:(image\/(?:png|jpeg|webp|gif));base64,\s*([A-Za-z
 // instead of falling back to a massive raw base64 transcript.
 const MAX_INLINE_IMAGE_URL_CHARS = 32_000_000;
 const INTERNAL_BROWSER_REPLAY_RE = /^\/browser\/replay\/[A-Za-z0-9._~%+-]+$/;
+
+export function browserReplayRecordingHref(replaySrc: string | undefined): string | undefined {
+  if (!replaySrc) return undefined;
+  const match = /^\/browser\/replay\/([A-Za-z0-9._~%+-]+)/.exec(replaySrc);
+  return match ? `/api/browser/recordings/${match[1]}` : undefined;
+}
 // Match the RFC-4122 structure (group boundaries + version 1-5 + variant 8-b),
 // same as the Svelte/audio artifact routes below — a bare {36} char class also
 // accepted 36 hyphens or a wrong-boundary string.
@@ -45,6 +51,7 @@ export type ToolResultWidget =
       text?: string;
       screenshotSrc?: string;
       replaySrc?: string;
+      recordingHref?: string;
     }
   | { kind: "inline-raster-image"; src: string; alt: string }
   | { kind: "inline-video"; src: string; label: string }
@@ -217,6 +224,7 @@ function browserRunWidget(value: unknown): ToolResultWidget | null {
     text: boundedText(result.textPreview ?? result.error),
     screenshotSrc,
     replaySrc,
+    recordingHref: browserReplayRecordingHref(replaySrc),
   };
 }
 


### PR DESCRIPTION
Closes #93

## Why
Opted-in draft PR.

## Receipt
- issue: https://github.com/acoyfellow/my-ax/issues/93
- kind: bug
- severity: p2
- labels: bug, triage:draft
- visual: public-web

## Files
See the Files changed tab on this PR. This body does not invent a file list.

## Proof
```sh
npx tsx --test src/desk-board.test.ts agents/src/policy.test.ts agents/src/harness.test.ts agents/src/github-hmac.test.ts
```

Worker never merges. Worker never approves. Human merge only.