### PR TITLE
fix: loop board tells a non-draft bug to write triage:draft

### DIFF
--- a/agents/src/orchestrate.ts
+++ b/agents/src/orchestrate.ts
@@ -75,7 +75,7 @@ export function formatLoopBoard(input: {
     lines.push(`blocked: missing ${head}. Sweep keeps the issue open until that head exists.`);
   }
   if (input.stage === "labeled" && !input.classification.draft) {
-    lines.push("next: Worker opens a ready PR after the head exists. Worker never merges.");
+    lines.push(`next: write triage:draft on a new comment after ${head} exists. Worker never merges.`);
   }
   if (input.error) lines.push(`error: ${input.error}`);
   return lines.join("\n");

--- a/agents/src/policy.test.ts
+++ b/agents/src/policy.test.ts
@@ -50,8 +50,8 @@ test("loop board names stage and next action", () => {
   const text = formatLoopBoard({ issueNumber: 52, classification, modelId: "grok-4.6", stage: "labeled" });
   assert.match(text, /stage: labeled/);
   assert.match(text, /issues\/52/);
-  assert.match(text, /ready PR/);
-  assert.doesNotMatch(text, /triage:draft/);
+  assert.match(text, /write triage:draft/);
+  assert.match(text, /bot\/issue-52/);
 });
 
 test("ready PR body names the issue, proof command, and never-merge rule", () => {


### PR DESCRIPTION
A non-draft bug is classify-only. The loop board was promising a ready PR after the head exists, which is false. Now it says to write triage:draft on a new comment after bot/issue-n exists.

Proof: npx tsx --test agents/src/policy.test.ts agents/src/harness.test.ts