### PR TITLE
fix: stop duplicate error issues and open the head branch

### DIFF
--- a/agents/src/harness.test.ts
+++ b/agents/src/harness.test.ts
@@ -39,6 +39,26 @@ function ports(ok = true): { github: GithubPort; terrarium: TerrariumPort; label
   };
 }
 
+test("an auto error issue creates its head branch and opens a ready PR", async () => {
+  const created: string[] = [];
+  const p = ports();
+  p.github.hasBranch = async () => false;
+  p.github.createBranch = async (name) => { created.push(name); };
+  const steps = await executeTriageWorkflow(env, {
+    number: 4242,
+    title: "bug: Invalid URL string.",
+    body: "## Auto error report\n\nfingerprint: `deadbeefdeadbeef`\norigin: server\nmessage: Invalid URL string.",
+    author: "owner",
+  }, p);
+  assert.deepEqual(created, ["bot/issue-4242"], "factory must create the missing head branch");
+  assert.ok(steps.some((s) => s.step === "branch"), "a branch step must be recorded");
+  assert.ok(steps.some((s) => s.step === "pr"), "a ready PR must be opened with no human step");
+  assert.ok(
+    !steps.some((s) => s.step === "stop" && /missing bot\/issue-4242/.test(s.reason)),
+    "the blocked-missing-branch dead end must be gone",
+  );
+});
+
 test("harness issue→label", async () => {
   const p = ports();
   const steps = await executeTriageWorkflow(env, { title: "screenshot fails", body: "bug: could not create image", author: "owner" }, p);

--- a/agents/src/orchestrate.ts
+++ b/agents/src/orchestrate.ts
@@ -23,6 +23,7 @@ export interface GithubPort {
   listPullFiles?(number: number): Promise<string[]>;
   commitsBehindMain?(headSha: string): Promise<number>;
   hasBranch?(name: string): Promise<boolean>;
+  createBranch?(name: string): Promise<void>;
   mergePr(number: number): Promise<void>;
   approvePr(number: number): Promise<void>;
   closePr?(number: number): Promise<void>;
@@ -46,6 +47,7 @@ export type TriageStep =
   | { step: "label"; labels: string[] }
   | { step: "comment" }
   | { step: "pr"; number: number }
+  | { step: "branch"; head: string }
   | { step: "dig"; runId: string; verified: boolean }
   | { step: "visual"; accepted: boolean }
   | { step: "stop"; reason: string };
@@ -119,7 +121,16 @@ export async function runTriage(input: IssueInput, ports: { github: GithubPort; 
     }
   } else if (shouldOpenDraft(classification) && issueNumber) {
     const head = `bot/issue-${issueNumber}`;
-    const exists = ports.github.hasBranch ? await ports.github.hasBranch(head) : true;
+    let exists = ports.github.hasBranch ? await ports.github.hasBranch(head) : true;
+    if (!exists && ports.github.createBranch) {
+      try {
+        await ports.github.createBranch(head);
+        exists = true;
+        steps.push({ step: "branch", head });
+      } catch (err) {
+        error = err instanceof Error ? err.message : String(err);
+      }
+    }
     if (!exists) {
       stage = "blocked-missing-branch";
       steps.push({ step: "stop", reason: `missing ${head}` });

--- a/agents/src/ports.ts
+++ b/agents/src/ports.ts
@@ -48,6 +48,16 @@ export function liveGithubPort(env: AgentsEnv & { GITHUB_TOKEN?: string; GITHUB_
         return false;
       }
     },
+    async createBranch(name) {
+      assertNoMergeAction("createBranch");
+      const main = await gh("/git/ref/heads/main") as { object?: { sha?: string } };
+      const sha = main.object?.sha;
+      if (!sha) throw new Error("main ref has no sha");
+      await gh("/git/refs", {
+        method: "POST",
+        body: JSON.stringify({ ref: `refs/heads/${name}`, sha }),
+      });
+    },
     async listPullFiles(number) {
       assertNoMergeAction("listPullFiles");
       const json = await gh(`/pulls/${number}/files?per_page=100`);

--- a/src/error-report.test.ts
+++ b/src/error-report.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { readFileSync } from "node:fs";
 import {
   errorFingerprint,
   formatAutoIssueBody,
@@ -20,6 +21,18 @@ test("client and server fingerprints stay apart", async () => {
   const server = await errorFingerprint({ origin: "server", message: "Invalid URL string." });
   const client = await errorFingerprint({ origin: "client", message: "Invalid URL string." });
   assert.notEqual(server, client);
+});
+
+test("a server-surfaced toast is not re-reported by the client", () => {
+  const store = readFileSync(new URL("./ui/store.svelte.ts", import.meta.url), "utf8");
+  const chat = readFileSync(new URL("./ui/Chat.svelte", import.meta.url), "utf8");
+  assert.match(store, /alreadyReported\b/);
+  assert.match(store, /if \(options\?\.alreadyReported\) return;/);
+  const agentFailures = chat.match(/pushError\(m\.body \|\| "Agent request failed"[^)]*\)/g) ?? [];
+  assert.ok(agentFailures.length >= 3, "expected the server-surfaced pushError call sites");
+  for (const call of agentFailures) {
+    assert.match(call, /alreadyReported: true/, `server-surfaced error must not double-file: ${call}`);
+  }
 });
 
 test("stack site ignores node internals", () => {
@@ -56,7 +69,7 @@ test("issue body names the fingerprint and forbids auto draft", () => {
   assert.doesNotMatch(body, /session:/);
   assert.doesNotMatch(body, /version:/);
   assert.doesNotMatch(body, /href:/);
-  assert.doesNotMatch(body, /opted-in draft PR/);
-  assert.match(body, /does not opt in a ready PR/);
+  assert.doesNotMatch(body, /does not opt in a ready PR/);
+  assert.match(body, /opts in a ready PR/);
   assert.equal(normalizeErrorMessage("  invalid url string  "), "Invalid URL string.");
 });

--- a/src/error-report.ts
+++ b/src/error-report.ts
@@ -90,7 +90,7 @@ export function formatAutoIssueBody(input: ErrorReportInput, fingerprint: string
     ...(site !== "unknown" ? [`site: ${site}`] : []),
     "",
     "This issue was opened by My AX from a live error. One fingerprint is one issue.",
-    "This report does not opt in a ready PR. A human adds that after a head branch exists.",
+    "This report opts in a ready PR. The factory opens the head branch and the pull request.",
   ].join("\n");
 }
 

--- a/src/ui/Chat.svelte
+++ b/src/ui/Chat.svelte
@@ -1534,7 +1534,7 @@
       }
       if (m.error) {
         dispatchTurn({ type: "frame", frame: { requestId: typeof m.id === "string" ? m.id : null, error: m.body || "Voice turn failed" } });
-        pushError(m.body || "Agent request failed");
+        pushError(m.body || "Agent request failed", { alreadyReported: true });
         activeRequestId = null;
         streamingMsgId = null;
         forgetActiveTurn();
@@ -1557,7 +1557,7 @@
       if (m.error) {
         dispatchTurn({ type: "frame", frame: { requestId: typeof m.id === "string" ? m.id : null, error: m.body || "Agent request failed" } });
         finalizeStreaming();
-        pushError(m.body || "Agent request failed");
+        pushError(m.body || "Agent request failed", { alreadyReported: true });
         responseRecoveryPending = false;
         activeRequestId = null;
         streamingMsgId = null;
@@ -1577,7 +1577,7 @@
       if (m.error) {
         dispatchTurn({ type: "frame", frame: { requestId: typeof m.id === "string" ? m.id : null, error: m.body || "Agent request failed" } });
         finalizeStreaming();
-        pushError(m.body || "Agent request failed");
+        pushError(m.body || "Agent request failed", { alreadyReported: true });
         responseRecoveryPending = false;
         activeRequestId = null;
         streamingMsgId = null;

--- a/src/ui/store.svelte.ts
+++ b/src/ui/store.svelte.ts
@@ -178,13 +178,14 @@ export function pushSystem(text: string) {
     { id: `toast-${++toastCounter}`, kind: "system", text },
   ];
 }
-export function pushError(text: string) {
+export function pushError(text: string, options?: { alreadyReported?: boolean }) {
   const next = clarifyOwnerError(text);
   if (toastBus.pending.some((toast) => toast.kind === "error" && toast.text === next)) return;
   toastBus.pending = [
     ...toastBus.pending,
     { id: `toast-${++toastCounter}`, kind: "error", text: next },
   ];
+  if (options?.alreadyReported) return;
   void reportClientError(text);
 }
 


### PR DESCRIPTION
## What was wrong

Three faults kept the factory from turning a live error into a pull request.

**1. One error filed two issues.** A server error reaches the browser as a toast,
and the browser filed it again. The two reports differ in `origin` and in stack
`site`, so they hash to two fingerprints. Issues #96 and #97 are the same error.

**2. The issue body contradicted the label.** The body said the report does not
opt in a ready PR. The policy opts in every auto error report and writes
`triage:draft`.

**3. Triage stopped forever when the head branch was absent.** Triage required
`bot/issue-<n>` and nothing ever created it, so every auto error issue stalled at
`blocked-missing-branch`.

## What changed

- `pushError` accepts `alreadyReported`. The three server-surfaced call sites in
  `Chat.svelte` set it, so the browser no longer files a second issue.
- The auto error body states that the report opts in a ready PR.
- `GithubPort` gains `createBranch`. Triage creates `bot/issue-<n>` from `main`
  and opens the ready PR.

The client and server fingerprints stay separate on purpose, so that test is
unchanged. The duplicate is removed at the reporting layer instead.

`createBranch` is not a merge action and stays inside `assertNoMergeAction`. The
Worker still never merges and never approves.

## Proof

```
npx tsx --test src/error-report.test.ts     6 pass
npx tsx --test agents/src/harness.test.ts   4 pass
npx tsx --test agents/src/policy.test.ts   18 pass
npm run check                               exit 0
```

The new harness test asserts a missing head branch now reaches `pr-opened`, and
fails if `blocked-missing-branch` returns.
