### PR TITLE
fix: give the work branch a commit so the ready PR is valid

### DIFF
--- a/agents/src/harness.test.ts
+++ b/agents/src/harness.test.ts
@@ -41,17 +41,21 @@ function ports(ok = true): { github: GithubPort; terrarium: TerrariumPort; label
 }
 
 test("an auto error issue creates its head branch and opens a ready PR", async () => {
-  const created: string[] = [];
+  const created: Array<{ name: string; seed?: { path: string; message: string; content: string } }> = [];
   const p = ports();
   p.github.hasBranch = async () => false;
-  p.github.createBranch = async (name) => { created.push(name); };
+  p.github.createBranch = async (name, seed) => { created.push({ name, seed }); };
   const steps = await executeTriageWorkflow(env, {
     number: 4242,
     title: "bug: Invalid URL string.",
     body: "## Auto error report\n\nfingerprint: `deadbeefdeadbeef`\norigin: server\nmessage: Invalid URL string.",
     author: "owner",
   }, p);
-  assert.deepEqual(created, ["bot/issue-4242"], "factory must create the missing head branch");
+  assert.equal(created.length, 1, "factory must create the missing head branch");
+  assert.equal(created[0]!.name, "bot/issue-4242");
+  assert.ok(created[0]!.seed, "branch must carry a seed commit or GitHub rejects the empty PR with 422");
+  assert.match(created[0]!.seed!.path, /issue-4242/);
+  assert.ok(created[0]!.seed!.content.length > 0, "seed commit must have content");
   assert.ok(steps.some((s) => s.step === "branch"), "a branch step must be recorded");
   assert.ok(steps.some((s) => s.step === "pr"), "a ready PR must be opened with no human step");
   assert.ok(

--- a/agents/src/orchestrate.ts
+++ b/agents/src/orchestrate.ts
@@ -24,7 +24,7 @@ export interface GithubPort {
   listPullFiles?(number: number): Promise<string[]>;
   commitsBehindMain?(headSha: string): Promise<number>;
   hasBranch?(name: string): Promise<boolean>;
-  createBranch?(name: string): Promise<void>;
+  createBranch?(name: string, seed?: { path: string; message: string; content: string }): Promise<void>;
   mergePr(number: number): Promise<void>;
   approvePr(number: number): Promise<void>;
   closePr?(number: number): Promise<void>;
@@ -52,6 +52,25 @@ export type TriageStep =
   | { step: "dig"; runId: string; verified: boolean }
   | { step: "visual"; accepted: boolean }
   | { step: "stop"; reason: string };
+
+export function formatBranchSeed(input: IssueInput, classification: Classification): string {
+  const issueNumber = input.number ?? 0;
+  return [
+    `# Work branch for issue #${issueNumber}`,
+    "",
+    `title: ${input.title}`,
+    `kind: ${classification.kind}`,
+    `severity: ${classification.severity}`,
+    "",
+    "The factory opened this branch so the pull request has a commit to carry.",
+    "Replace this file with the fix, then push to this branch.",
+    "",
+    `proof: ${PROOF_COMMAND}`,
+    "",
+    "A human merges. The Worker never merges and never approves.",
+    "",
+  ].join("\n");
+}
 
 export function formatLoopBoard(input: {
   issueNumber: number;
@@ -126,7 +145,11 @@ export async function runTriage(input: IssueInput, ports: { github: GithubPort; 
     let exists = ports.github.hasBranch ? await ports.github.hasBranch(head) : true;
     if (!exists && ports.github.createBranch) {
       try {
-        await ports.github.createBranch(head);
+        await ports.github.createBranch(head, {
+          path: `.factory/issue-${issueNumber}.md`,
+          message: `chore: open work branch for issue #${issueNumber}`,
+          content: formatBranchSeed(input, classification),
+        });
         exists = true;
         steps.push({ step: "branch", head });
       } catch (err) {

--- a/agents/src/ports.ts
+++ b/agents/src/ports.ts
@@ -48,7 +48,7 @@ export function liveGithubPort(env: AgentsEnv & { GITHUB_TOKEN?: string; GITHUB_
         return false;
       }
     },
-    async createBranch(name) {
+    async createBranch(name, seed) {
       assertNoMergeAction("createBranch");
       const main = await gh("/git/ref/heads/main") as { object?: { sha?: string } };
       const sha = main.object?.sha;
@@ -56,6 +56,15 @@ export function liveGithubPort(env: AgentsEnv & { GITHUB_TOKEN?: string; GITHUB_
       await gh("/git/refs", {
         method: "POST",
         body: JSON.stringify({ ref: `refs/heads/${name}`, sha }),
+      });
+      if (!seed) return;
+      await gh(`/contents/${encodeURI(seed.path)}`, {
+        method: "PUT",
+        body: JSON.stringify({
+          message: assertPublicText(seed.message),
+          content: btoa(unescape(encodeURIComponent(assertPublicText(seed.content)))),
+          branch: name,
+        }),
       });
     },
     async listPullFiles(number) {

--- a/proof/factory-canary.sh
+++ b/proof/factory-canary.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="${CANARY_REPO:-acoyfellow/my-ax}"
+TIMEOUT="${CANARY_TIMEOUT:-240}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STAMP="$(date -u +%Y%m%d%H%M%S)"
+FP="$(printf 'canary%s' "$STAMP" | shasum -a 256 | cut -c1-16)"
+ISSUE=""
+PR=""
+BRANCH=""
+
+log() { printf '[canary] %s\n' "$*" >&2; }
+fail() { printf '[canary][FAIL] %s\n' "$*" >&2; exit 1; }
+
+cleanup() {
+  set +e
+  [ -n "$PR" ] && gh pr close "$PR" --repo "$REPO" --comment "Factory canary cleanup." >/dev/null 2>&1
+  [ -n "$ISSUE" ] && gh issue close "$ISSUE" --repo "$REPO" --reason "not planned" --comment "Factory canary cleanup." >/dev/null 2>&1
+  [ -n "$BRANCH" ] && gh api -X DELETE "repos/$REPO/git/refs/heads/$BRANCH" >/dev/null 2>&1
+  set -e
+}
+trap cleanup EXIT
+
+log "filing canary auto error issue (fingerprint $FP)"
+BODY="## Auto error report
+
+fingerprint: \`$FP\`
+origin: server
+message: Factory canary probe.
+site: canary.ts
+
+This issue was opened by My AX from a live error. One fingerprint is one issue.
+This report opts in a ready PR. The factory opens the head branch and the pull request."
+
+ISSUE="$(gh issue create --repo "$REPO" --title "bug: Factory canary probe." --body "$BODY" --json number --jq .number 2>/dev/null \
+  || gh issue create --repo "$REPO" --title "bug: Factory canary probe." --body "$BODY" | grep -oE '[0-9]+$')"
+[ -n "$ISSUE" ] || fail "could not create the canary issue"
+BRANCH="bot/issue-$ISSUE"
+log "issue #$ISSUE filed; waiting up to ${TIMEOUT}s for the Worker to open a ready PR"
+
+DEADLINE=$(( $(date +%s) + TIMEOUT ))
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+  PR="$(gh pr list --repo "$REPO" --state open --head "$BRANCH" --json number --jq '.[0].number // empty')"
+  [ -n "$PR" ] && break
+  sleep 10
+done
+
+[ -n "$PR" ] || fail "no ready PR for $BRANCH within ${TIMEOUT}s; the factory did not auto-triage the issue"
+log "PROVEN: the Worker opened ready PR #$PR for issue #$ISSUE with no human step"
+
+DRAFT="$(gh pr view "$PR" --repo "$REPO" --json isDraft --jq .isDraft)"
+[ "$DRAFT" = "false" ] || fail "PR #$PR is a draft; the factory must open a ready PR"
+
+cleanup
+trap - EXIT
+PR=""; ISSUE=""; BRANCH=""
+
+OPEN_ISSUES="$(gh issue list --repo "$REPO" --state open --json number --jq 'length')"
+OPEN_PRS="$(gh pr list --repo "$REPO" --state open --json number --jq 'length')"
+[ "$OPEN_ISSUES" = "0" ] || fail "expected 0 open issues, found $OPEN_ISSUES"
+[ "$OPEN_PRS" = "0" ] || fail "expected 0 open PRs, found $OPEN_PRS"
+log "PROVEN: 0 open issues, 0 open PRs"
+
+log "running npm run check on the current tree"
+( cd "$ROOT" && npm run check >/tmp/canary-check.log 2>&1 ) || fail "npm run check failed; see /tmp/canary-check.log"
+log "PROVEN: npm run check exits 0"
+
+printf '\n# pass factory-canary: a new auto error issue auto-triages into a ready PR; 0 issues, 0 PRs, check green\n'


### PR DESCRIPTION
## What the canary found

`createBranch` pointed `bot/issue-<n>` at the exact sha of `main`, so the pull
request had no commits between head and base. GitHub refuses that with 422.

The unit test passed because the fake port only recorded the branch name. The
live canary caught it on issue #99: `stage: pr-failed`, `error: github /pulls 422`.

## What changed

- `createBranch` accepts a seed and writes `.factory/issue-<n>.md` on the new
  branch, so the pull request carries one commit.
- The harness test asserts the seed exists and has content, so an empty branch
  cannot regress.
- Adds `proof/factory-canary.sh`. It files a live auto error issue and fails
  unless the Worker opens a ready PR with no human step, then asserts zero open
  issues, zero open PRs, and a green `npm run check`.

## Proof

```
npx tsx --test agents/src/harness.test.ts agents/src/policy.test.ts   23 pass
npm run check                                                        exit 0
```

The end-to-end canary run is the real gate and is reported separately.