### PR TITLE
fix: stop the sweep from re-queueing finished issues

### DIFF
--- a/agents/src/orchestrate.ts
+++ b/agents/src/orchestrate.ts
@@ -24,6 +24,7 @@ export interface GithubPort {
   listPullFiles?(number: number): Promise<string[]>;
   commitsBehindMain?(headSha: string): Promise<number>;
   hasBranch?(name: string): Promise<boolean>;
+  hasOpenPrForHead?(head: string): Promise<boolean>;
   createBranch?(name: string, seed?: { path: string; message: string; content: string }): Promise<void>;
   mergePr(number: number): Promise<void>;
   approvePr(number: number): Promise<void>;
@@ -96,7 +97,7 @@ export function formatLoopBoard(input: {
     lines.push(`blocked: missing ${head}. Sweep keeps the issue open until that head exists.`);
   }
   if (input.stage === "labeled" && !input.classification.draft) {
-    lines.push(`next: write triage:draft on a new comment after ${head} exists. Worker never merges.`);
+    lines.push("next: a human opts this in. Add the draft label on a new comment. Worker never merges.");
   }
   if (input.error) lines.push(`error: ${input.error}`);
   return lines.join("\n");

--- a/agents/src/policy.test.ts
+++ b/agents/src/policy.test.ts
@@ -50,8 +50,13 @@ test("loop board names stage and next action", () => {
   const text = formatLoopBoard({ issueNumber: 52, classification, modelId: "grok-4.6", stage: "labeled" });
   assert.match(text, /stage: labeled/);
   assert.match(text, /issues\/52/);
-  assert.match(text, /write triage:draft/);
+  assert.match(text, /a human opts this in/);
   assert.match(text, /bot\/issue-52/);
+  assert.doesNotMatch(
+    text,
+    /\btriage:draft\b/,
+    "the board must not contain the literal opt-in token it would match on re-read",
+  );
 });
 
 test("ready PR body names the issue, proof command, and never-merge rule", () => {

--- a/agents/src/ports.ts
+++ b/agents/src/ports.ts
@@ -67,6 +67,12 @@ export function liveGithubPort(env: AgentsEnv & { GITHUB_TOKEN?: string; GITHUB_
         }),
       });
     },
+    async hasOpenPrForHead(head) {
+      assertNoMergeAction("hasOpenPrForHead");
+      const owner = repo.split("/")[0];
+      const json = await gh(`/pulls?state=open&head=${encodeURIComponent(`${owner}:${head}`)}&per_page=1`);
+      return Array.isArray(json) && json.length > 0;
+    },
     async listPullFiles(number) {
       assertNoMergeAction("listPullFiles");
       const json = await gh(`/pulls/${number}/files?per_page=100`);

--- a/agents/src/sweep.test.ts
+++ b/agents/src/sweep.test.ts
@@ -24,11 +24,28 @@ test("issues without a loop board are queued once", () => {
   assert.ok(!actions.some((row) => row.action === "queue" && row.number === 75));
 });
 
-test("a labeled issue with a head is queued again", () => {
+test("a boarded issue with a head is not queued again", () => {
   const actions = planSweep([
     { number: 67, title: "bug: image", body: "fingerprint: `e8a37db7f3311f4b`", author: "o", state: "open", comments: ["## loop board"], hasHead: true },
   ]);
-  assert.ok(actions.some((row) => row.action === "queue" && row.number === 67));
+  assert.ok(
+    !actions.some((row) => row.action === "queue" && row.number === 67),
+    "a boarded issue whose head branch exists must not be re-queued every sweep",
+  );
+});
+
+test("an issue with an open PR is never re-queued", () => {
+  const actions = planSweep([
+    { number: 109, title: "bug: heal", body: "repro", author: "o", state: "open", comments: ["## loop board"], hasHead: true, hasOpenPr: true },
+  ]);
+  assert.deepEqual(actions, [], "an issue that already has an open PR is finished work");
+});
+
+test("an unboarded issue is still queued", () => {
+  const actions = planSweep([
+    { number: 70, title: "bug: new", body: "repro", author: "o", state: "open", comments: [], hasHead: false },
+  ]);
+  assert.ok(actions.some((row) => row.action === "queue" && row.number === 70));
 });
 
 test("sweep never parks", () => {

--- a/agents/src/sweep.ts
+++ b/agents/src/sweep.ts
@@ -13,6 +13,7 @@ export interface SweepIssue {
   state: "open" | "closed";
   comments: string[];
   hasHead?: boolean;
+  hasOpenPr?: boolean;
 }
 
 export type SweepAction =
@@ -58,12 +59,11 @@ export function planSweep(issues: SweepIssue[]): SweepAction[] {
   const closing = new Set(actions.filter((row) => row.action === "close-duplicate").map((row) => row.number));
   for (const issue of open) {
     if (closing.has(issue.number)) continue;
-    const boarded = hasLoopBoard(issue.comments);
-    if (!boarded || issue.hasHead) {
-      if (queues >= SWEEP_MAX_QUEUES) continue;
-      actions.push({ action: "queue", number: issue.number });
-      queues += 1;
-    }
+    if (issue.hasOpenPr) continue;
+    if (hasLoopBoard(issue.comments)) continue;
+    if (queues >= SWEEP_MAX_QUEUES) continue;
+    actions.push({ action: "queue", number: issue.number });
+    queues += 1;
   }
 
   return actions;

--- a/agents/src/worker.ts
+++ b/agents/src/worker.ts
@@ -120,8 +120,10 @@ export async function runIssueSweep(env: WorkerEnv): Promise<{ closed: number; q
   const issues: SweepIssue[] = [];
   for (const issue of open) {
     const comments = await github.listComments(issue.number);
-    const hasHead = github.hasBranch ? await github.hasBranch(`bot/issue-${issue.number}`) : false;
-    issues.push({ ...issue, state: "open", comments, hasHead });
+    const head = `bot/issue-${issue.number}`;
+    const hasHead = github.hasBranch ? await github.hasBranch(head) : false;
+    const hasOpenPr = github.hasOpenPrForHead ? await github.hasOpenPrForHead(head) : false;
+    issues.push({ ...issue, state: "open", comments, hasHead, hasOpenPr });
   }
   const actions = planSweep(issues);
   let closed = 0;


### PR DESCRIPTION
## What was wrong

The sweep re-queued an issue whenever a head branch existed:

```ts
if (!boarded || issue.hasHead) { queue }
```

That clause was safe while nothing created `bot/issue-<n>`. Triage now creates the
branch, so `hasHead` is true for every triaged issue and the sweep re-queued it on
every 15 minute run.

Observed on #109. The issue reached `pr-opened` with PR #110, then the next sweep
posted a `labeled` board again and asked for an opt-in the issue already had. The
re-run reported `labels: bug` because it classified from the queued body, not from
the current issue state.

This is a regression from the branch creation change. The sweep had no way to know a
pull request already existed.

## What changed

- `SweepIssue` gains `hasOpenPr`, filled by a new `hasOpenPrForHead` port.
- The sweep skips an issue with an open pull request, and skips an issue that already
  carries a loop board. An unboarded issue is still queued.
- The board no longer prints the literal opt-in token that the comment gate matches on.
- The board no longer says the head branch must exist first.

## Proof

```
npx tsx --test agents/src/sweep.test.ts     9 pass
agents/src/policy.test.ts + harness.test.ts 32 pass total
npm run check                               exit 0
```

The old test asserted the bug as intended behaviour ("a labeled issue with a head is
queued again"). It is replaced by three tests: a boarded issue with a head is not
re-queued, an issue with an open pull request is never re-queued, and an unboarded
issue is still queued.