### PR TITLE
fix: stop the review from re-posting on every retry

### DIFF
--- a/agents/src/review.test.ts
+++ b/agents/src/review.test.ts
@@ -52,6 +52,21 @@ test("auto-error flood PRs are closed", async () => {
   assert.ok(port.actions.some((a) => a.startsWith("comment:")));
 });
 
+test("a rejected self-review does not fail the review or duplicate the comment", async () => {
+  const port = github();
+  port.requestChanges = async () => {
+    throw new Error("github /pulls/61/reviews 422");
+  };
+  const receipt = await runReview(pull({
+    number: 61,
+    title: "feat: file one GitHub issue per live error",
+    body: "proof",
+  }), { github: port });
+  assert.equal(receipt.decision, "request-changes", "the verdict must still stand");
+  const comments = port.actions.filter((a) => a.startsWith("comment:"));
+  assert.equal(comments.length, 1, "exactly one review comment, never a retry storm");
+});
+
 test("failed proof requests changes and never approves", async () => {
   const port = github();
   const receipt = await runReview(pull({

--- a/agents/src/review.ts
+++ b/agents/src/review.ts
@@ -85,9 +85,13 @@ export async function runReview(
     if (!ports.github.closePr) throw new Error("closePr missing");
     await ports.github.closePr(input.number ?? 0);
   }
-  if (receipt.decision === "request-changes") {
-    if (!ports.github.requestChanges) throw new Error("requestChanges missing");
-    await ports.github.requestChanges(input.number ?? 0, formatReviewComment(receipt));
+  if (receipt.decision === "request-changes" && ports.github.requestChanges) {
+    await ports.github.requestChanges(input.number ?? 0, formatReviewComment(receipt)).catch((error) => {
+      console.warn("review_request_changes_skipped", {
+        number: input.number,
+        err: error instanceof Error ? error.message : String(error),
+      });
+    });
   }
   return receipt;
 }

--- a/agents/src/workflow-entry.ts
+++ b/agents/src/workflow-entry.ts
@@ -2,6 +2,8 @@ import { WorkflowEntrypoint, type WorkflowEvent, type WorkflowStep } from "cloud
 import { executeAuditWorkflow, executeDigWorkflow, executeReviewWorkflow, executeTriageWorkflow, type AgentsEnv } from "./workflows";
 import type { IssueInput, PullInput } from "./policy";
 import { liveGithubPort, liveTerrariumPort } from "./ports";
+import { formatReviewComment, reviewPull } from "./review";
+import { requireGateway } from "./policy";
 
 export class TriageWorkflow extends WorkflowEntrypoint<AgentsEnv, IssueInput> {
   async run(event: WorkflowEvent<IssueInput>, step: WorkflowStep) {
@@ -30,7 +32,31 @@ export class AuditWorkflow extends WorkflowEntrypoint<AgentsEnv, PullInput> {
 export class ReviewWorkflow extends WorkflowEntrypoint<AgentsEnv, PullInput & { head?: string }> {
   async run(event: WorkflowEvent<PullInput & { head?: string }>, step: WorkflowStep) {
     const github = liveGithubPort(this.env);
-    return step.do("review", () => executeReviewWorkflow(this.env, event.payload, { github }));
+    requireGateway(this.env);
+    const receipt = await step.do("review-verdict", async () => reviewPull(event.payload));
+    if (receipt.decision === "ignore") return receipt;
+    await step.do("review-comment", async () => {
+      await github.comment(event.payload.number ?? 0, formatReviewComment(receipt));
+      return true;
+    });
+    if (receipt.decision === "close" && github.closePr) {
+      await step.do("review-close", async () => {
+        await github.closePr!(event.payload.number ?? 0);
+        return true;
+      });
+    }
+    if (receipt.decision === "request-changes" && github.requestChanges) {
+      await step.do("review-request-changes", async () => {
+        await github.requestChanges!(event.payload.number ?? 0, formatReviewComment(receipt)).catch((error) => {
+          console.warn("review_request_changes_skipped", {
+            number: event.payload.number,
+            err: error instanceof Error ? error.message : String(error),
+          });
+        });
+        return true;
+      });
+    }
+    return receipt;
   }
 }
 


### PR DESCRIPTION
## What was wrong

`runReview` posted the receipt, then called `requestChanges` inside the same
`step.do("review", ...)`. GitHub refuses a review on your own pull request, so the
call threw, Workflows retried the whole step, and the receipt was posted again on
each retry.

Observed on PR #115: six identical receipts at 13:34:15, 13:34:26, 13:34:47,
13:35:27, 13:36:48, 13:39:29. The gaps double, which is workflow retry backoff.
`GET /pulls/115/reviews` returned `0`, so not one of the six attempts recorded a
review.

Review fails closed to `request-changes` whenever proof is missing, and no runner
produces proof yet, so every factory pull request took the throwing path.

## What changed

- The workflow splits the verdict, the comment, the close, and the request-changes
  into separate steps. A failure in a later step never repeats the comment, because
  each completed step is checkpointed.
- A rejected `requestChanges` is logged and does not fail the review. The receipt
  comment is the artifact that matters, and the Worker still never approves or merges.

## Proof

```
npx tsx --test agents/src/review.test.ts    7 pass
sweep + policy + harness                   32 pass
npm run check                              exit 0
```

The new test injects a throwing `requestChanges` and asserts the verdict still
stands and exactly one comment is posted.