### PR TITLE
fix: Invalid URL string.

### DIFF
--- a/.factory/issue-125.md
+++ b/.factory/issue-125.md
@@ -1,0 +1,12 @@
+# Work branch for issue #125
+
+title: bug: Invalid URL string.
+kind: bug
+severity: p2
+
+The factory opened this branch so the pull request has a commit to carry.
+Replace this file with the fix, then push to this branch.
+
+proof: npx tsx --test src/desk-board.test.ts agents/src/policy.test.ts agents/src/harness.test.ts agents/src/github-hmac.test.ts
+
+A human merges. The Worker never merges and never approves.


### PR DESCRIPTION
Closes #125

## Why
Live error; open a ready PR.

## Receipt
- issue: https://github.com/acoyfellow/my-ax/issues/125
- kind: bug
- severity: p2
- labels: bug, triage:draft
- visual: none

## Files
See the Files changed tab on this PR. This body does not invent a file list.

## Proof
```sh
npx tsx --test src/desk-board.test.ts agents/src/policy.test.ts agents/src/harness.test.ts agents/src/github-hmac.test.ts
```

Worker never merges. Worker never approves. Human merge only.