### PR TITLE
fix: a Decide link never points back at the desk

### DIFF
--- a/src/desk-board.test.ts
+++ b/src/desk-board.test.ts
@@ -31,6 +31,13 @@ test("Open source rejects same-origin paths; Decide keeps them", () => {
   assert.equal(board.cards[0]?.decisionHref, "/api/decisions/run-decision-test");
 });
 
+test("Decide rejects desk and attention self-links", () => {
+  const desk = upsertDeskCard(emptyDeskBoard(), { id: "self-desk", title: "x", decisionHref: "/?action=desk" });
+  assert.equal(desk.cards[0]?.decisionHref, null);
+  const attention = upsertDeskCard(emptyDeskBoard(), { id: "self-attn", title: "x", decisionHref: "/?action=attention" });
+  assert.equal(attention.cards[0]?.decisionHref, null);
+});
+
 test("emptyDeskBoard is a clearable single artifact", () => {
   const cleared = emptyDeskBoard("t-clear");
   assert.deepEqual(cleared.cards, []);

--- a/src/desk-board.ts
+++ b/src/desk-board.ts
@@ -110,5 +110,10 @@ function cleanDecisionHref(value: unknown): string | null {
   if (typeof value !== "string") return null;
   const href = value.trim();
   if (!href || href.length > 2048) return null;
-  return sameOriginPath(href) ?? cleanRemoteHref(href);
+  const path = sameOriginPath(href);
+  if (path) {
+    if (/^\/\?action=/i.test(path)) return null;
+    return path;
+  }
+  return cleanRemoteHref(href);
 }


### PR DESCRIPTION
## What was wrong

`cleanDecisionHref` accepted any same origin path. A card built with
`/?action=desk` or `/?action=attention` therefore rendered a Decide control
that navigated to the page the owner was already on. The click reloaded the desk
and the decision could not be made.

## What changed

A same origin path that is a `/?action=` deep link is rejected, so the card shows
no Decide control instead of a control that cannot work. Real decision links such
as `/api/decisions/<id>` are unchanged.

## Proof

The new test fails without the source change:

```
✖ Decide rejects desk and attention self-links
ℹ pass 7   ℹ fail 1
```

With the fix:

```
npx tsx --test src/desk-board.test.ts   8 pass
npm run check                           exit 0
```