### PR TITLE
fix: a concurrent error report no longer files a duplicate issue

### DIFF
--- a/src/error-issue.test.ts
+++ b/src/error-issue.test.ts
@@ -17,8 +17,8 @@ function makeEnv(opts: { token?: string; existing?: { fingerprint: string; numbe
         bind(...args: unknown[]) { bound = args; return stmt; },
         async first<T = unknown>() {
           if (/FROM error_issue_fingerprints/.test(q)) {
-            const [owner, fingerprint, cutoff] = bound as [string, string, string];
-            const hit = rows.find((row) => row.fingerprint === fingerprint && row.lastSeen >= cutoff);
+            const [owner, fingerprint, cutoff] = bound as [string, string, string | undefined];
+            const hit = rows.find((row) => row.fingerprint === fingerprint && (cutoff === undefined || row.lastSeen >= cutoff));
             void owner;
             return (hit ? { issue_number: hit.number, issue_url: hit.url } : null) as T;
           }
@@ -66,6 +66,46 @@ test("missing token skips without throwing", async () => {
     message: "Invalid URL string.",
   });
   assert.deepEqual(result, { skipped: "not-configured" });
+});
+
+test("a concurrent report for one fingerprint files exactly one issue", async () => {
+  const { env } = makeEnv({ token: "t" });
+  let created = 0;
+  let firstIsCreating: (() => void) | undefined;
+  const firstReachedGithub = new Promise<void>((resolve) => { firstIsCreating = resolve; });
+  let releaseFirst: (() => void) | undefined;
+  const firstMayFinish = new Promise<void>((resolve) => { releaseFirst = resolve; });
+
+  const post: typeof fetch = (async (url: string, init?: RequestInit) => {
+    if (init?.method === "POST") {
+      created += 1;
+      const number = 200 + created;
+      if (created === 1) {
+        firstIsCreating?.();
+        await firstMayFinish;
+      }
+      return new Response(JSON.stringify({ number, html_url: `https://github.com/acoyfellow/my-ax/issues/${number}` }), { status: 201 });
+    }
+    if (/\/issues\/0$/.test(String(url))) return new Response("{}", { status: 404 });
+    return new Response(JSON.stringify({ state: "open" }), { status: 200 });
+  }) as unknown as typeof fetch;
+
+  const input = {
+    origin: "client" as const,
+    message: "Invalid URL string.",
+    stack: "Error: Invalid URL string.\n    at buildUrl (index.js:1:1)",
+  };
+
+  const a = fileOwnerErrorIssue(env, "owner@example.com", input, post);
+  await firstReachedGithub;
+  const b = fileOwnerErrorIssue(env, "owner@example.com", input, post);
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  releaseFirst?.();
+  const [ra, rb] = await Promise.all([a, b]);
+
+  assert.equal(created, 1, "the second report must not create a second GitHub issue");
+  const numbers = [ra, rb].map((r) => ("number" in r ? r.number : null));
+  assert.equal(numbers[0], numbers[1], "both reports must return the same issue number");
 });
 
 test("same fingerprint reuses the open issue", async () => {

--- a/src/error-issue.ts
+++ b/src/error-issue.ts
@@ -27,11 +27,19 @@ export async function fileOwnerErrorIssue(
   if (!token) return { skipped: "not-configured" };
   const fingerprint = await errorFingerprint(input);
   const claimed = await claimFingerprint(env, ownerEmail, fingerprint);
-  if (!claimed.created && claimed.issue_number && claimed.issue_url) {
-    const open = await githubIssueIsOpen(token, repo, claimed.issue_number, post);
-    if (open) {
-      await touchFingerprint(env, ownerEmail, fingerprint).catch(() => undefined);
-      return { number: claimed.issue_number, url: claimed.issue_url, fingerprint, created: false };
+  if (!claimed.created) {
+    if (claimed.issue_number && claimed.issue_url) {
+      const open = await githubIssueIsOpen(token, repo, claimed.issue_number, post);
+      if (open) {
+        await touchFingerprint(env, ownerEmail, fingerprint).catch(() => undefined);
+        return { number: claimed.issue_number, url: claimed.issue_url, fingerprint, created: false };
+      }
+    } else {
+      const settled = await awaitClaimedIssue(env, ownerEmail, fingerprint);
+      if (settled) {
+        await touchFingerprint(env, ownerEmail, fingerprint).catch(() => undefined);
+        return { number: settled.issue_number, url: settled.issue_url, fingerprint, created: false };
+      }
     }
   }
   const created = await createGithubIssue(token, repo, input, fingerprint, post);
@@ -89,6 +97,24 @@ async function claimFingerprint(
     issue_number: existing?.issue_number,
     issue_url: existing?.issue_url,
   };
+}
+
+async function awaitClaimedIssue(
+  env: Env,
+  ownerEmail: string,
+  fingerprint: string,
+  attempts = 8,
+  waitMs = 250,
+): Promise<{ issue_number: number; issue_url: string } | null> {
+  const owner = ownerEmail.toLowerCase();
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    await new Promise((resolve) => setTimeout(resolve, waitMs));
+    const row = await env.DB.prepare(
+      "SELECT issue_number, issue_url FROM error_issue_fingerprints WHERE owner_email = ? AND fingerprint = ?",
+    ).bind(owner, fingerprint).first<{ issue_number: number; issue_url: string }>();
+    if (row?.issue_number && row.issue_url) return row;
+  }
+  return null;
 }
 
 async function touchFingerprint(env: Env, ownerEmail: string, fingerprint: string): Promise<void> {


### PR DESCRIPTION
## Evidence

Issues #124 and #126 are the same error. They share fingerprint `11e31a64813db3fd`
and were both created at `2026-08-22T16:01:04Z`.

## Root cause

`claimFingerprint` reserves the row with `INSERT OR IGNORE`, which is atomic, but
seeds `issue_number = 0` and writes the real number only after GitHub answers.

A second report for the same fingerprint inside that window loses the claim, reads
`issue_number = 0`, and the guard `claimed.issue_number && ...` treats `0` as
absent. It skips the open check and creates a second issue.

## What changed

The loser of the claim now waits for the winner to publish the number, and reuses
it. The claim still reserves the slot, so no report is dropped.

## Proof

The test drives the exact interleaving: the second report claims while the first is
still in flight to GitHub. Without the source change:

```
✖ a concurrent report for one fingerprint files exactly one issue
  AssertionError: the second report must not create a second GitHub issue
    actual: 2, expected: 1
```

With the fix:

```
npx tsx --test src/error-issue.test.ts   6 pass
npm run check                            exit 0
```