### PR TITLE
test: add the error queue drained gate

### DIFF
--- a/.no-added-comments-allow
+++ b/.no-added-comments-allow
@@ -1,1 +1,2 @@
 proof/factory-no-loop.sh
+proof/error-queue-drained.sh

--- a/agents/README.md
+++ b/agents/README.md
@@ -31,9 +31,12 @@ These gates are the receipts. Prose is not proof.
 bash proof/factory-canary.sh    # an auto-error issue reaches a ready PR with no human step
 bash proof/factory-no-loop.sh   # one pr-opened board, no stage regression, at most one
                                 # review receipt, 0 open issues, 0 open PRs, check green
+bash proof/error-queue-drained.sh  # no open auto-error issue predates the running deploy
 ```
 
 `factory-no-loop.sh` waits past two 15 minute sweeps on purpose. The re-queue bug it guards only appears across sweep ticks.
+
+`error-queue-drained.sh` compares each open auto-error issue against the deploy time of the running Worker. A merged but undeployed fix looks exactly like a broken fix, so the gate reads the live deploy rather than `main`.
 
 Hunt ticks that only file issues: [HUNT.md](./HUNT.md).
 

--- a/proof/error-queue-drained.sh
+++ b/proof/error-queue-drained.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="${QUEUE_REPO:-acoyfellow/my-ax}"
+WORKER="${QUEUE_WORKER:-my-ax}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+log() { printf '[queue] %s\n' "$*" >&2; }
+fail() { printf '[queue][FAIL] %s\n' "$*" >&2; exit 1; }
+
+cd "$ROOT"
+
+DEPLOYED_AT="$("$ROOT/node_modules/.bin/wrangler" deployments list --name "$WORKER" 2>/dev/null \
+  | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}' | tail -1)"
+[ -n "$DEPLOYED_AT" ] || fail "could not read the deployed version time for $WORKER"
+DEPLOYED_EPOCH="$(date -j -f "%Y-%m-%dT%H:%M:%S" "$DEPLOYED_AT" +%s 2>/dev/null || date -d "$DEPLOYED_AT" +%s)"
+log "the running app was deployed at ${DEPLOYED_AT}Z"
+
+STALE=0
+while read -r number created; do
+  [ -n "$number" ] || continue
+  BODY="$(gh issue view "$number" --repo "$REPO" --json body --jq .body)"
+  printf '%s' "$BODY" | grep -q "Auto error report" || continue
+  CREATED_EPOCH="$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$created" +%s 2>/dev/null || date -d "$created" +%s)"
+  if [ "$CREATED_EPOCH" -lt "$DEPLOYED_EPOCH" ]; then
+    log "issue #$number was reported at $created, before the running app was deployed"
+    STALE=$((STALE + 1))
+  else
+    log "issue #$number was reported at $created, after the deploy, so it is current work"
+  fi
+done < <(gh issue list --repo "$REPO" --state open --json number,createdAt --jq '.[]|"\(.number) \(.createdAt)"')
+
+[ "$STALE" -eq 0 ] || fail "$STALE open auto-error issue(s) predate the running app; fix and deploy, or close with a reason"
+log "PROVEN: no open auto-error issue predates the running deploy"
+
+git fetch origin main --quiet
+LOCAL_MAIN="$(git rev-parse origin/main)"
+DEPLOYED_SHA="$(gh api "repos/$REPO/commits/main" --jq .sha)"
+[ "$LOCAL_MAIN" = "$DEPLOYED_SHA" ] || fail "origin/main and the fetched main disagree"
+log "PROVEN: main is $LOCAL_MAIN"
+
+for gate in proof/factory-canary.sh proof/factory-no-loop.sh; do
+  [ -f "$gate" ] || fail "$gate is missing; the factory gates must not be removed"
+done
+log "PROVEN: the factory gates are still present"
+
+npm run check >/tmp/error-queue-check.log 2>&1 || fail "npm run check failed; see /tmp/error-queue-check.log"
+log "PROVEN: npm run check exits 0"
+
+printf '\n# pass error-queue-drained: no stale auto-error issue, factory gates intact, check green\n'


### PR DESCRIPTION
## Why

The heal fix in #110 was merged on 2026-08-22 and the app was last deployed on
2026-08-19. The same error kept arriving because the fix was never running. A
merged but undeployed fix looks exactly like a broken fix.

## What the gate proves

- It reads the deploy time of the running Worker, not `main`.
- It fails when an open auto-error issue was reported before that deploy.
- An issue reported after the deploy is current work, not a stale one, so the gate
  does not demand an empty queue while the app is live.
- The factory gates are still present, and `npm run check` is green.

## Proof

Run now, with #130 still open from before the deploy:

```
[queue] the running app was deployed at 2026-08-23T14:43:32Z
[queue] issue #130 was reported at 2026-08-22T16:38:18Z, before the running app was deployed
[queue][FAIL] 1 open auto-error issue(s) predate the running app
GATE EXIT=1
```

The gate fails for the correct reason. The docs drift test from #121 also caught
this gate being undocumented, so `agents/README.md` now names it.