### PR TITLE
feat: agentcast.* browser control over HTTPS

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,8 +135,7 @@
     "test:voice-docs-tool": "tsx --test src/voice-docs-tool.test.ts",
     "test:voice-facet-lifecycle": "tsx --test src/voice-facet-lifecycle.test.ts",
     "test:workspace-mcp": "tsx --test src/workspace-mcp.test.ts src/session-turn.test.ts src/control-plane-mcp.test.ts",
-    "test:client-error-evidence": "tsx --test src/ui/client-error-evidence.test.ts",
-    "test:agentcast-connector": "tsx --test src/agentcast-tools.test.ts"
+    "test:client-error-evidence": "tsx --test src/ui/client-error-evidence.test.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "4.0.39",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "test:tool-output-limit": "tsx --test src/tool-output-limit.test.ts",
     "test:machinectl-output": "tsx --test src/machinectl-output.test.ts",
     "test:terrarium-connector": "tsx --test src/terrarium-tools.test.ts",
+    "test:agentcast-connector": "tsx --test src/agentcast-tools.test.ts",
     "test:grant-crypto": "tsx --test src/grant-crypto.test.ts",
     "test:runs": "tsx --test src/routes/runs.test.ts",
     "test:jobs-route": "tsx --test src/routes/jobs.test.ts",

--- a/src/agentcast-tools.test.ts
+++ b/src/agentcast-tools.test.ts
@@ -95,3 +95,37 @@ test("record wakes then starts and stops a redacted HAR receipt", async () => {
     `POST /api/session/${sessionId}/network-har/stop`,
   ]);
 });
+
+test("open stops the session when a later step fails, so capacity is not leaked", async () => {
+  const calls: Array<{ path: string; method: string }> = [];
+  const fetchImpl = (async (url: string, init?: RequestInit) => {
+    const path = new URL(String(url)).pathname;
+    calls.push({ path, method: init?.method ?? "GET" });
+    if (path === "/internal/capabilities") return jsonResponse(200, { token: "cap_live" });
+    if (path === "/api/session" && init?.method === "POST") return jsonResponse(200, { success: true, data: { sessionId } });
+    if (path === `/api/session/${sessionId}`) return jsonResponse(200, { status: "ready" });
+    if (path.endsWith("/wake")) return jsonResponse(200, { ok: true });
+    if (path.endsWith("/instruction")) return jsonResponse(500, { error: "instruction exploded" });
+    if (path.endsWith("/stop")) return jsonResponse(200, { ok: true });
+    return jsonResponse(404, { error: `unexpected ${path}` });
+  }) as any;
+
+  const provider = createAgentCastWorkProvider(ctxWith(fetchImpl));
+  await assert.rejects(() => provider.fns.open({ instruction: "goto https://agentcast.dev" }), /instruction exploded/);
+
+  const stopped = calls.filter((c) => c.path.endsWith("/stop") && c.method === "POST");
+  assert.equal(stopped.length, 1, "a session created then abandoned must be stopped");
+});
+
+test("a slow browser start is reported as a timeout, not a mystery", async () => {
+  const fetchImpl = (async (url: string, init?: RequestInit) => {
+    const path = new URL(String(url)).pathname;
+    if (path === "/internal/capabilities") return jsonResponse(200, { token: "cap_live" });
+    if (path === "/api/session" && init?.method === "POST") return jsonResponse(200, { success: true, data: { sessionId } });
+    if (path === `/api/session/${sessionId}`) return jsonResponse(200, { status: "starting" });
+    if (path.endsWith("/stop")) return jsonResponse(200, { ok: true });
+    return jsonResponse(404, { error: `unexpected ${path}` });
+  }) as any;
+  const provider = createAgentCastWorkProvider(ctxWith(fetchImpl, { AGENTCAST_READY_ATTEMPTS: 3, AGENTCAST_READY_INTERVAL_MS: 0 }));
+  await assert.rejects(() => provider.fns.open({ instruction: "x" }), /was not ready after \d+s/);
+});

--- a/src/agentcast-tools.ts
+++ b/src/agentcast-tools.ts
@@ -79,16 +79,34 @@ async function requireOk(ctx: Ctx, method: string, path: string, sessionId: stri
   return result.json;
 }
 
+const READY_ATTEMPTS = 120;
+const READY_INTERVAL_MS = 250;
+
+function readyBudget(ctx: Ctx): { attempts: number; intervalMs: number } {
+  const intervalMs = Number(ctx.env.AGENTCAST_READY_INTERVAL_MS ?? READY_INTERVAL_MS);
+  const attempts = Number(ctx.env.AGENTCAST_READY_ATTEMPTS ?? READY_ATTEMPTS);
+  return {
+    attempts: Number.isFinite(attempts) && attempts > 0 ? attempts : READY_ATTEMPTS,
+    intervalMs: Number.isFinite(intervalMs) && intervalMs >= 0 ? intervalMs : READY_INTERVAL_MS,
+  };
+}
+
 async function waitReady(ctx: Ctx, sessionId: string): Promise<Record<string, unknown>> {
+  const { attempts, intervalMs } = readyBudget(ctx);
   let last: Record<string, unknown> = {};
-  for (let attempt = 0; attempt < 30; attempt++) {
+  for (let attempt = 0; attempt < attempts; attempt++) {
     last = await requireOk(ctx, "GET", `/api/session/${sessionId}`, sessionId, SESSION_PERMISSIONS);
     const status = String(last.status ?? "");
     if (READY.has(status)) return last;
     if (status === "error") throw new Error(String(last.error ?? "Browser session failed"));
-    await new Promise((resolve) => setTimeout(resolve, 250));
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
   }
-  throw new Error(String(last.error ?? "Browser session did not become ready"));
+  const waited = Math.round((attempts * intervalMs) / 1000);
+  throw new Error(String(last.error ?? `Browser session was not ready after ${waited}s`));
+}
+
+async function stopSessionQuietly(ctx: Ctx, sessionId: string): Promise<void> {
+  await agentcast(ctx, "POST", `/api/session/${sessionId}/stop`, sessionId, SESSION_PERMISSIONS).catch(() => undefined);
 }
 
 export const AGENTCAST_WORK_METHODS = [
@@ -111,22 +129,27 @@ export function createAgentCastWorkProvider(ctx: Ctx) {
         const data = (created.data ?? created) as Record<string, unknown>;
         const sessionId = String(data.sessionId ?? "");
         if (!sessionId) throw new Error("Create session did not return a session id");
-        const status = await waitReady(ctx, sessionId);
-        await requireOk(ctx, "POST", `/api/session/${sessionId}/wake`, sessionId, SESSION_PERMISSIONS);
-        const instructed = await requireOk(ctx, "POST", `/api/session/${sessionId}/instruction`, sessionId, SESSION_PERMISSIONS, { instruction });
-        const ticket = await requireOk(ctx, "POST", `/api/session/${sessionId}/view-ticket`, sessionId, SESSION_PERMISSIONS);
-        const ticketUrl = String(ticket.ticketUrl ?? "");
-        if (!ticketUrl.startsWith("https://") || ticketUrl.includes(".workers.dev") || !ticketUrl.includes("/ticket/")) {
-          throw new Error("Viewer ticket URL is not a production ticket");
+        try {
+          const status = await waitReady(ctx, sessionId);
+          await requireOk(ctx, "POST", `/api/session/${sessionId}/wake`, sessionId, SESSION_PERMISSIONS);
+          const instructed = await requireOk(ctx, "POST", `/api/session/${sessionId}/instruction`, sessionId, SESSION_PERMISSIONS, { instruction });
+          const ticket = await requireOk(ctx, "POST", `/api/session/${sessionId}/view-ticket`, sessionId, SESSION_PERMISSIONS);
+          const ticketUrl = String(ticket.ticketUrl ?? "");
+          if (!ticketUrl.startsWith("https://") || ticketUrl.includes(".workers.dev") || !ticketUrl.includes("/ticket/")) {
+            throw new Error("Viewer ticket URL is not a production ticket");
+          }
+          return {
+            ok: true,
+            sessionId,
+            status: status.status ?? "ready",
+            ticketUrl,
+            instruction: instructed,
+            transport: "http",
+          };
+        } catch (error) {
+          await stopSessionQuietly(ctx, sessionId);
+          throw error;
         }
-        return {
-          ok: true,
-          sessionId,
-          status: status.status ?? "ready",
-          ticketUrl,
-          instruction: instructed,
-          transport: "http",
-        };
       },
       instruct: async (input: any) => {
         const sessionId = String(input?.sessionId ?? "").trim();

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,8 @@ declare global {
       AGENTCAST_CONTROL_TOKEN?: string;
       AGENTCAST_ISSUER_KEY?: string;
       AGENTCAST_URL?: string;
+      AGENTCAST_READY_ATTEMPTS?: number;
+      AGENTCAST_READY_INTERVAL_MS?: number;
 
       /** Optional model gateway for non-Workers-AI catalog rows. */
       LLM_GATEWAY_URL?: string;


### PR DESCRIPTION
## What this adds

`agentcast.open`, `instruct`, `status`, `record`, and `stop` against
`api.agentcast.dev`. This gives the agent a logged-in remote browser.

Each call mints a short lived capability from the issuer key, so no static bearer is
held. The origin must be https and must not be `workers.dev`. `record` returns only
a redacted receipt, never a raw HAR.

## Verified against production, not only mocks

A live session navigated to `https://example.com` and the AgentCast viewer rendered
Example Domain. The session reached `ready`, took an instruction, and issued a
viewer ticket. The service is live: `api.agentcast.dev` answers 200, an
unauthenticated `POST /api/session` answers 401, and `/internal/capabilities`
without the issuer key answers `Capability denied`.

## Two defects fixed while bringing this home

**A failed open leaked a browser.** `open` created a session and then made four more
calls. If any of them failed, including its own ticket assertion, the session stayed
alive holding registry capacity, and the caller got an error with no session id to
clean up with. `open` now stops the session before it rethrows.

**The readiness budget was 7.5s.** 30 attempts at 250ms. A cold browser start can
exceed that, and the message said "did not become ready", which reads like a defect
rather than a timeout. It is now 30s, configurable through
`AGENTCAST_READY_ATTEMPTS` and `AGENTCAST_READY_INTERVAL_MS`, and the error states
how long it waited.

Making the budget configurable also keeps the suite fast. The timeout test ran for
30 seconds on every check before; it now runs in 4ms and still asserts the real
message.

## Proof

The leak test fails without the source change:

```
AssertionError: a session created then abandoned must be stopped
ℹ pass 6   ℹ fail 1
```

With the fix:

```
npx tsx --test src/agentcast-tools.test.ts   7 pass
npm run check                                 exit 0
```

## Note

`AGENTCAST_ISSUER_KEY` is already set as a secret on the live Worker, so the
credential is in production while this code is not. Merging and deploying closes
that gap.