### PR TITLE
test: add the live AgentCast gate

### DIFF
--- a/.no-added-comments-allow
+++ b/.no-added-comments-allow
@@ -1,2 +1,3 @@
 proof/factory-no-loop.sh
 proof/error-queue-drained.sh
+proof/agentcast-live.sh

--- a/agents/README.md
+++ b/agents/README.md
@@ -32,11 +32,14 @@ bash proof/factory-canary.sh    # an auto-error issue reaches a ready PR with no
 bash proof/factory-no-loop.sh   # one pr-opened board, no stage regression, at most one
                                 # review receipt, 0 open issues, 0 open PRs, check green
 bash proof/error-queue-drained.sh  # no open auto-error issue predates the running deploy
+bash proof/agentcast-live.sh       # the live browser opens, instructs, and returns a redacted receipt
 ```
 
 `factory-no-loop.sh` waits past two 15 minute sweeps on purpose. The re-queue bug it guards only appears across sweep ticks.
 
 `error-queue-drained.sh` compares each open auto-error issue against the deploy time of the running Worker. A merged but undeployed fix looks exactly like a broken fix, so the gate reads the live deploy rather than `main`.
+
+`agentcast-live.sh` calls the real service and needs `AGENTCAST_ISSUER_KEY`, so it is opt-in and never runs in CI. It stops every session it opens, including on failure, because a gate that leaks browser capacity is a broken gate.
 
 Hunt ticks that only file issues: [HUNT.md](./HUNT.md).
 

--- a/proof/agentcast-live.sh
+++ b/proof/agentcast-live.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ORIGIN="${AGENTCAST_URL:-https://api.agentcast.dev}"
+KEY="${AGENTCAST_ISSUER_KEY:-}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SESSION=""
+WORK="$(mktemp -d)"
+
+log() { printf '[agentcast] %s\n' "$*" >&2; }
+fail() { printf '[agentcast][FAIL] %s\n' "$*" >&2; exit 1; }
+
+cleanup() {
+  set +e
+  if [ -n "$SESSION" ]; then
+    TOKEN="$(mint "$SESSION" 2>/dev/null)"
+    [ -n "$TOKEN" ] && curl -s -o /dev/null -X POST "$ORIGIN/api/session/$SESSION/stop" \
+      -H "authorization: Bearer $TOKEN" --max-time 30
+    log "stopped session"
+  fi
+  rm -rf "$WORK"
+  set -e
+}
+trap cleanup EXIT
+
+mint() {
+  local sid="$1"
+  curl -s -X POST "$ORIGIN/internal/capabilities" \
+    -H "authorization: Bearer $KEY" -H "content-type: application/json" \
+    -d "{\"tenantId\":\"owner\",\"sessionId\":\"$sid\",\"profileId\":\"my-ax\",\"permissions\":[\"sessions:create\",\"session:observe\",\"session:input\",\"session:control\",\"cdp:full\",\"network:record\",\"network:receipt\"],\"audience\":\"$ORIGIN\",\"ttlMs\":300000}" \
+    --max-time 30 | jq -r '.token // empty'
+}
+
+call() {
+  local method="$1" path="$2" sid="$3" body="${4:-}"
+  local token; token="$(mint "$sid")"
+  [ -n "$token" ] || fail "could not mint a capability"
+  if [ -n "$body" ]; then
+    curl -s -X "$method" "$ORIGIN$path" -H "authorization: Bearer $token" \
+      -H "content-type: application/json" -d "$body" --max-time 60
+  else
+    curl -s -X "$method" "$ORIGIN$path" -H "authorization: Bearer $token" --max-time 60
+  fi
+}
+
+[ -n "$KEY" ] || fail "AGENTCAST_ISSUER_KEY is required; this gate calls the live service"
+command -v jq >/dev/null || fail "jq is required"
+
+log "opening a live session on $ORIGIN"
+CREATED="$(call POST /api/session '*' '{"name":"my-ax-gate"}')"
+SESSION="$(printf '%s' "$CREATED" | jq -r '.data.sessionId // .sessionId // empty')"
+[ -n "$SESSION" ] || fail "create did not return a session id"
+log "PROVEN: a session was created"
+
+READY=""
+for _ in $(seq 1 120); do
+  STATUS="$(call GET "/api/session/$SESSION" "$SESSION" | jq -r '.status // empty')"
+  case "$STATUS" in
+    ready|active) READY="$STATUS"; break ;;
+    error) fail "the session reported an error while starting" ;;
+  esac
+  sleep 1
+done
+[ -n "$READY" ] || fail "the session was not ready in time"
+log "PROVEN: the session reached $READY"
+
+call POST "/api/session/$SESSION/wake" "$SESSION" >/dev/null
+TICKET="$(call POST "/api/session/$SESSION/view-ticket" "$SESSION" | jq -r '.ticketUrl // empty')"
+case "$TICKET" in
+  https://*/ticket/*) : ;;
+  *) fail "the viewer ticket is not a production ticket URL" ;;
+esac
+printf '%s' "$TICKET" | grep -q '.workers.dev' && fail "the viewer ticket points at workers.dev"
+log "PROVEN: a production viewer ticket was issued"
+
+call POST "/api/session/$SESSION/instruction" "$SESSION" '{"instruction":"goto https://example.com"}' >/dev/null
+log "PROVEN: the session accepted an instruction"
+
+call POST "/api/session/$SESSION/network-har/start" "$SESSION" '{"maxDurationMs":8000,"maxEntries":20}' >/dev/null
+call POST "/api/session/$SESSION/instruction" "$SESSION" '{"instruction":"goto https://example.com/?gate=secret-probe-value"}' >/dev/null
+sleep 3
+call POST "/api/session/$SESSION/network-har/stop" "$SESSION" > "$WORK/receipt.json"
+RECEIPT="$WORK/receipt.json"
+jq -e '.receipt' "$RECEIPT" >/dev/null 2>&1 || fail "stop did not return a receipt"
+log "PROVEN: a HAR capture produced a receipt"
+
+grep -qi 'secret-probe-value' "$RECEIPT" && fail "the receipt leaked a query string"
+grep -qiE '"(cookie|set-cookie|authorization)"' "$RECEIPT" && fail "the receipt leaked a forbidden header"
+jq -e '.receipt.entries // .receipt.log.entries | not' "$RECEIPT" >/dev/null 2>&1 \
+  || fail "the receipt carries raw HAR entries; it must be a receipt, not a capture"
+log "PROVEN: the receipt is redacted, with no query string, header, or raw HAR leak"
+
+call POST "/api/session/$SESSION/stop" "$SESSION" >/dev/null
+GONE="$(call GET "/api/session/$SESSION" "$SESSION" | jq -r '.status // "gone"')"
+case "$GONE" in
+  ready|active) fail "the session is still running after stop" ;;
+esac
+SESSION=""
+log "PROVEN: stop freed the session"
+
+cd "$ROOT"
+git fetch origin main --quiet
+MAIN="$(git rev-parse origin/main)"
+DEPLOYED="$("$ROOT/node_modules/.bin/wrangler" deployments list --name my-ax 2>/dev/null | grep -c "$(git rev-parse --short origin/main)" || true)"
+log "main is $MAIN"
+
+npm run check >"$WORK/check.log" 2>&1 || fail "npm run check failed"
+log "PROVEN: npm run check exits 0"
+
+printf '\n# pass agentcast-live: open, instruct, redacted receipt, stop, all against the live service\n'

--- a/proof/agentcast-live.sh
+++ b/proof/agentcast-live.sh
@@ -86,8 +86,10 @@ log "PROVEN: a HAR capture produced a receipt"
 
 grep -qi 'secret-probe-value' "$RECEIPT" && fail "the receipt leaked a query string"
 grep -qiE '"(cookie|set-cookie|authorization)"' "$RECEIPT" && fail "the receipt leaked a forbidden header"
-jq -e '.receipt.entries // .receipt.log.entries | not' "$RECEIPT" >/dev/null 2>&1 \
-  || fail "the receipt carries raw HAR entries; it must be a receipt, not a capture"
+jq -e '[.. | objects | select(has("entries")) | .entries | select(type=="array")] | length == 0' "$RECEIPT" >/dev/null 2>&1 \
+  || fail "the receipt carries raw HAR entries at some depth; it must be a receipt, not a capture"
+jq -e '[.. | strings | select(test("^https?://[^\\s]*[?#]"))] | length == 0' "$RECEIPT" >/dev/null 2>&1 \
+  || fail "the receipt carries a URL with a query string or fragment; URLs must be origin only"
 log "PROVEN: the receipt is redacted, with no query string, header, or raw HAR leak"
 
 call POST "/api/session/$SESSION/stop" "$SESSION" >/dev/null


### PR DESCRIPTION
## Why

The five `agentcast.*` tools have 7 unit tests and all of them are mocked. The only
live evidence is a screenshot. `record` has never been exercised against the real
service at all, and it is the HAR egress boundary.

## What the gate proves

Against the real `api.agentcast.dev`:

- a session is created and reaches ready
- the viewer ticket is a production `https://.../ticket/...` URL and not workers.dev
- the session accepts an instruction
- a bounded HAR capture returns a receipt

Then it asserts the receipt is actually redacted. It navigates with a marker query
string and requires that the marker does not appear in the receipt, that no cookie,
set-cookie, or authorization header appears, and that no raw HAR entries are
present. A receipt that carries the capture is not a receipt.

Finally it stops the session and asserts it is no longer running.

## Safety

The gate creates real browsers, so it stops every session it opens from a trap,
including on failure. A gate that leaks capacity is a broken gate.

It needs `AGENTCAST_ISSUER_KEY`, so it is opt-in and never runs in CI, like
`factory-canary.sh`. It prints no token, no key, and no ticket URL.

## Current result

```
[agentcast][FAIL] AGENTCAST_ISSUER_KEY is required; this gate calls the live service
EXIT=1
```

It fails closed without the key, which is correct. The live run is blocked on
placing that key locally.

`npm run check` exits 0, and the docs drift test from #121 required this gate to be
named in `agents/README.md`.