### PR TITLE
test: assert the real AgentCast receipt contract

### DIFF
--- a/proof/agentcast-live.sh
+++ b/proof/agentcast-live.sh
@@ -86,11 +86,13 @@ log "PROVEN: a HAR capture produced a receipt"
 
 grep -qi 'secret-probe-value' "$RECEIPT" && fail "the receipt leaked a query string"
 grep -qiE '"(cookie|set-cookie|authorization)"' "$RECEIPT" && fail "the receipt leaked a forbidden header"
-jq -e '[.. | objects | select(has("entries")) | .entries | select(type=="array")] | length == 0' "$RECEIPT" >/dev/null 2>&1 \
-  || fail "the receipt carries raw HAR entries at some depth; it must be a receipt, not a capture"
 jq -e '[.. | strings | select(test("^https?://[^\\s]*[?#]"))] | length == 0' "$RECEIPT" >/dev/null 2>&1 \
   || fail "the receipt carries a URL with a query string or fragment; URLs must be origin only"
-log "PROVEN: the receipt is redacted, with no query string, header, or raw HAR leak"
+jq -e '[.. | objects | select(has("url") or has("headers") or has("request") or has("response") or has("postData") or has("content"))] | length == 0' "$RECEIPT" >/dev/null 2>&1 \
+  || fail "the receipt carries a raw HAR shape; a receipt entry has origin and hostname, never url, headers, or bodies"
+jq -e '[.receipt.entries // [] | .[] | select((.origin | type) != "string" or (.hostname | type) != "string")] | length == 0' "$RECEIPT" >/dev/null 2>&1 \
+  || fail "a receipt entry is missing the redacted origin and hostname fields"
+log "PROVEN: the receipt is redacted, with origin only entries and no header, body, or URL leak"
 
 call POST "/api/session/$SESSION/stop" "$SESSION" >/dev/null
 GONE="$(call GET "/api/session/$SESSION" "$SESSION" | jq -r '.status // "gone"')"


### PR DESCRIPTION
## What was wrong

The gate rejected any `entries` array at any depth. A `NetworkReceipt` carries
`entries` **by design**, so the check would have failed a correct receipt the first
time it ran against the live service.

Reading the published SDK surface (read only), a receipt entry is:

```
method, status, type, origin, hostname, startedAt, durationMs,
requestBytes, responseBytes
```

No `url`, no headers, no bodies. `redactNetworkCapture` returns null for any capture
that has a request or response body, or any forbidden header, so the receipt is
redacted by construction.

## What changed

The gate now asserts the real contract:

- no URL with a query string or a fragment
- no raw HAR shape: `url`, `headers`, `request`, `response`, `postData`, `content`
- every entry carries the redacted `origin` and `hostname`

## Proof

Fixtures shaped like the real contract:

```
good.json    (real NetworkReceipt)      -> PASSES
rawhar.json  (url + cookie header)      -> FAILS (caught)
nohost.json  (entry missing hostname)   -> FAILS (caught)
```

`npm run check` exits 0.

## Note

This was found by reading the SDK, not by running the gate. The live run is still
blocked on `AGENTCAST_ISSUER_KEY`. Had it run first, it would have reported a
redaction failure that was really a bug in the assertion.