### PR TITLE
fix: open recovers a profile held by a stale session

### DIFF
--- a/proof/agentcast-live.sh
+++ b/proof/agentcast-live.sh
@@ -48,6 +48,10 @@ command -v jq >/dev/null || fail "jq is required"
 
 log "opening a live session on $ORIGIN"
 CREATED="$(call POST /api/session '*' '{"name":"my-ax-gate"}')"
+if printf '%s' "$CREATED" | grep -qi 'already active'; then
+  log "a stale session held the profile; taking it over"
+  CREATED="$(call POST /api/session '*' '{"name":"my-ax-gate","takeover":true}')"
+fi
 SESSION="$(printf '%s' "$CREATED" | jq -r '.data.sessionId // .sessionId // empty')"
 [ -n "$SESSION" ] || fail "create did not return a session id"
 log "PROVEN: a session was created"

--- a/src/agentcast-tools.test.ts
+++ b/src/agentcast-tools.test.ts
@@ -129,3 +129,33 @@ test("a slow browser start is reported as a timeout, not a mystery", async () =>
   const provider = createAgentCastWorkProvider(ctxWith(fetchImpl, { AGENTCAST_READY_ATTEMPTS: 3, AGENTCAST_READY_INTERVAL_MS: 0 }));
   await assert.rejects(() => provider.fns.open({ instruction: "x" }), /was not ready after \d+s/);
 });
+
+test("open takes over a stale profile instead of failing with 409", async () => {
+  const bodies: string[] = [];
+  let created = 0;
+  const fetchImpl = (async (url: string, init?: RequestInit) => {
+    const path = new URL(String(url)).pathname;
+    if (path === "/internal/capabilities") return jsonResponse(200, { token: "cap_live" });
+    if (path === "/api/session" && init?.method === "POST") {
+      const body = String(init.body ?? "");
+      bodies.push(body);
+      if (!body.includes("takeover")) return jsonResponse(409, { success: false, error: "Profile is already active" });
+      created += 1;
+      return jsonResponse(200, { success: true, data: { sessionId } });
+    }
+    if (path === `/api/session/${sessionId}`) return jsonResponse(200, { status: "ready" });
+    if (path.endsWith("/wake")) return jsonResponse(200, { ok: true });
+    if (path.endsWith("/instruction")) return jsonResponse(200, { ok: true });
+    if (path.endsWith("/view-ticket")) return jsonResponse(200, { ticketUrl: "https://api.agentcast.dev/ticket/t" });
+    if (path.endsWith("/stop")) return jsonResponse(200, { ok: true });
+    return jsonResponse(404, { error: `unexpected ${path}` });
+  }) as any;
+
+  const provider = createAgentCastWorkProvider(ctxWith(fetchImpl));
+  const res = await provider.fns.open({ instruction: "goto https://example.com" });
+  assert.equal(res.ok, true);
+  assert.equal(created, 1, "the retry must create exactly one session");
+  assert.equal(bodies.length, 2, "the first attempt is plain, the second takes over");
+  assert.ok(!bodies[0].includes("takeover"), "the first attempt must not force a takeover");
+  assert.ok(bodies[1].includes("takeover"), "the retry must ask for a takeover");
+});

--- a/src/agentcast-tools.ts
+++ b/src/agentcast-tools.ts
@@ -125,7 +125,13 @@ export function createAgentCastWorkProvider(ctx: Ctx) {
       open: async (input: any) => {
         const instruction = String(input?.instruction ?? "").trim();
         if (!instruction) throw new Error("agentcast.open requires a non-empty {instruction}");
-        const created = await requireOk(ctx, "POST", "/api/session", "*", CREATE_PERMISSIONS, { name: typeof input?.name === "string" ? input.name : "my-ax" });
+        const name = typeof input?.name === "string" ? input.name : "my-ax";
+        let attempt = await agentcast(ctx, "POST", "/api/session", "*", CREATE_PERMISSIONS, { name });
+        if (attempt.code === 409) {
+          attempt = await agentcast(ctx, "POST", "/api/session", "*", CREATE_PERMISSIONS, { name, takeover: true });
+        }
+        if (attempt.code < 200 || attempt.code >= 300) fail("/api/session", attempt);
+        const created = attempt.json;
         const data = (created.data ?? created) as Record<string, unknown>;
         const sessionId = String(data.sessionId ?? "");
         if (!sessionId) throw new Error("Create session did not return a session id");


### PR DESCRIPTION
## Found by running the gate against production

The first live run failed:

```
[agentcast] opening a live session on https://api.agentcast.dev
[agentcast][FAIL] create did not return a session id
```

`POST /api/session` was answering:

```
{"success":false,"error":"Profile is already active"}
HTTP 409
```

A session from earlier testing still held the `my-ax` profile, so `open` could not
start a browser at all. Worse, there is no endpoint that lists sessions, so the id
needed to stop the old one was unobtainable. The tool was wedged with no way out
except a human with the id.

Probing the create options showed `takeover: true` is the supported recovery, and
`force` and `replace` are not.

## What changed

`open` retries once with `takeover` when create answers 409. The first attempt stays
plain, so a healthy profile is never seized. The gate does the same.

## Proof

The whole gate now passes against the live service:

```
PROVEN: a session was created
PROVEN: the session reached ready
PROVEN: a production viewer ticket was issued
PROVEN: the session accepted an instruction
PROVEN: a HAR capture produced a receipt
PROVEN: the receipt is redacted, with origin only entries and no header, body, or URL leak
PROVEN: stop freed the session
GATE EXIT=0
```

That is the first live exercise of `record`, which is the HAR egress boundary. The
gate navigates with a marker query string and requires it to be absent from the
receipt.

The unit test drives the exact sequence: the first create is plain and answers 409,
the retry carries `takeover`, and exactly one session is created.

```
npx tsx --test src/agentcast-tools.test.ts   8 pass
npm run check                                 exit 0
```