### PR TITLE
test: the live gate reads the issuer key itself

### DIFF
--- a/proof/agentcast-live.sh
+++ b/proof/agentcast-live.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+ENV_FILE="${AGENTCAST_ENV_FILE:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/my-ax-private/employee.env}"
+if [ -z "${AGENTCAST_ISSUER_KEY:-}" ] && [ -r "$ENV_FILE" ]; then
+  AGENTCAST_ISSUER_KEY="$(sed -n 's/^AGENTCAST_ISSUER_KEY=//p' "$ENV_FILE" | tail -1)"
+  AGENTCAST_URL="${AGENTCAST_URL:-$(sed -n 's/^AGENTCAST_URL=//p' "$ENV_FILE" | tail -1)}"
+fi
+
 ORIGIN="${AGENTCAST_URL:-https://api.agentcast.dev}"
 KEY="${AGENTCAST_ISSUER_KEY:-}"
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -43,7 +49,7 @@ call() {
   fi
 }
 
-[ -n "$KEY" ] || fail "AGENTCAST_ISSUER_KEY is required; this gate calls the live service"
+[ -n "$KEY" ] || fail "AGENTCAST_ISSUER_KEY is required; export it or put it in $ENV_FILE"
 command -v jq >/dev/null || fail "jq is required"
 
 log "opening a live session on $ORIGIN"


### PR DESCRIPTION
## Why

The gate passed for me and failed for everything else, because I had sourced
`employee.env` in my shell first. Running the bare command gave:

```
[agentcast][FAIL] AGENTCAST_ISSUER_KEY is required
```

A gate that needs an undocumented shell prelude is not a gate. Anything that runs
the proof command as written, including the terraloop verifier, saw a false failure.

## What changed

The gate reads `AGENTCAST_ISSUER_KEY` and `AGENTCAST_URL` from
`my-ax-private/employee.env` when they are not already in the environment. An
explicit environment variable still wins, and `AGENTCAST_ENV_FILE` overrides the
path. The failure message now names the file it looked in.

Nothing secret is printed, and the key stays in the gitignored 600 file.

## Proof

Run with the variables explicitly removed from the environment:

```
env -u AGENTCAST_ISSUER_KEY -u AGENTCAST_URL bash proof/agentcast-live.sh
...
PROVEN: the receipt is redacted, with origin only entries and no header, body, or URL leak
PROVEN: stop freed the session
GATE EXIT=0
```

`npm run check` exits 0.