### PR TITLE
feat: review verifies a PR against its own preview deploy

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -15,7 +15,7 @@ GitHub cannot do Access. Do not put the gateway Worker on `workers.dev` and do n
 | Sweep (cron `*/15`) | scheduled | close same-fingerprint duplicates; queue only issues that have no loop board and no open PR | comment storm, re-queue a boarded issue |
 | `DigWorkflow` | hard bug | spawn Terrarium with a host `taskProof`, wait, proceed only if the receipt and the proof both hold | trust a callback or a receipt without `taskProof` |
 | `AuditWorkflow` | `pull_request.opened/synchronize` | receipt comment with files and behind-main when GitHub returns them | approve or merge |
-| `ReviewWorkflow` | same PR events | owner/`bot/issue-*` only: one proof receipt per step, request changes when it can, or close flood | approve, merge, or touch foreign PRs |
+| `ReviewWorkflow` | same PR events | owner/`bot/issue-*` only: one proof receipt per step, verify the PR against its own live preview deploy, request changes when it can, or close flood | approve, merge, or touch foreign PRs |
 
 A live error report is an opt-in for a **ready** GitHub PR (`draft: false`), not a GitHub draft. The method is `openReadyPr`. The head is `bot/issue-<n>`, and triage creates it with a seed commit, because a branch at the exact SHA of `main` makes `/pulls` answer 422. The body uses `Closes #<n>` and does not invent a file list.
 

--- a/agents/src/preview-check.test.ts
+++ b/agents/src/preview-check.test.ts
@@ -1,0 +1,115 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { previewUrlForPull, isPreviewUrlForPull, previewFindings, type PreviewCheck } from "./preview-check";
+
+import { reviewPull, formatReviewComment } from "./review";
+
+const SUFFIX = ".preview.example";
+const url = (n: number) => previewUrlForPull(n, SUFFIX);
+
+const HEAD = "abc1234def5678";
+const okProof = { proofExit: 0, proofLog: "# pass everything" };
+const owner = { author: "acoyfellow", title: "fix: thing", body: "body", number: 144, head: "bot/issue-143", draft: false, headSha: HEAD, files: [] as string[], behindMain: 0, previewHostSuffix: SUFFIX };
+
+test("a preview URL is derived from the pull number", () => {
+  assert.equal(url(144), "https://pr-144.preview.example");
+  assert.throws(() => previewUrlForPull(0, SUFFIX));
+  assert.throws(() => previewUrlForPull(-3, SUFFIX));
+  assert.throws(() => previewUrlForPull(144, ""), /not configured/);
+});
+
+test("a preview URL belonging to another pull request is refused", () => {
+  assert.equal(isPreviewUrlForPull("https://pr-144.preview.example", 144, SUFFIX), true);
+  assert.equal(isPreviewUrlForPull("https://pr-999.preview.example", 144, SUFFIX), false);
+  assert.equal(isPreviewUrlForPull("https://preview.example", 144, SUFFIX), false);
+  assert.equal(isPreviewUrlForPull("http://pr-144.preview.example", 144, SUFFIX), false);
+  assert.equal(isPreviewUrlForPull("https://pr-144.evil.example.com", 144, SUFFIX), false);
+  assert.equal(isPreviewUrlForPull("not a url", 144, SUFFIX), false);
+});
+
+test("a missing preview blocks the review", () => {
+  const result = previewFindings({ number: 144, head: HEAD }, SUFFIX);
+  assert.equal(result.ok, false);
+  assert.match(result.findings[0], /preview missing/);
+});
+
+test("a preview that answers anything but 200 blocks the review", () => {
+  const result = previewFindings({ number: 144, head: HEAD, preview: { url: url(144), status: 502, version: HEAD } }, SUFFIX);
+  assert.equal(result.ok, false);
+  assert.match(result.findings[0], /did not answer 200 \(got 502\)/);
+});
+
+test("a preview running a different commit blocks the review", () => {
+  const result = previewFindings({ number: 144, head: HEAD, preview: { url: url(144), status: 200, version: "9999999aaaa" } }, SUFFIX);
+  assert.equal(result.ok, false);
+  assert.match(result.findings[0], /not this head/);
+});
+
+test("a preview with no reported version blocks the review", () => {
+  const result = previewFindings({ number: 144, head: HEAD, preview: { url: url(144), status: 200 } }, SUFFIX);
+  assert.equal(result.ok, false);
+  assert.match(result.findings[0], /did not report a deployed version/);
+});
+
+test("a healthy preview running this head passes and names the URL", () => {
+  const result = previewFindings({ number: 144, head: HEAD, preview: { url: url(144), status: 200, version: HEAD } }, SUFFIX);
+  assert.equal(result.ok, true);
+  assert.match(result.findings[0], /verified against the live preview for this pull request/);
+});
+
+test("review refuses ready-for-owner when the proof passed but the preview is missing", () => {
+  const receipt = reviewPull({ ...owner, ...okProof, head: HEAD });
+  assert.equal(receipt.decision, "request-changes");
+  assert.match(receipt.findings.join(" "), /preview missing/);
+});
+
+test("review reaches ready-for-owner only with a verified preview, and records the URL", () => {
+  const receipt = reviewPull({
+    ...owner,
+    ...okProof,
+    head: HEAD,
+    preview: { url: url(144), status: 200, version: HEAD },
+  });
+  assert.equal(receipt.decision, "ready-for-owner");
+  assert.equal(receipt.neverApprove, true);
+  assert.equal(receipt.neverMerge, true);
+  assert.match(receipt.findings.join(" "), /verified against the live preview for this pull request/);
+});
+
+test("a preview borrowed from another pull request cannot pass the review", () => {
+  const receipt = reviewPull({
+    ...owner,
+    ...okProof,
+    head: HEAD,
+    preview: { url: url(999), status: 200, version: HEAD },
+  });
+  assert.equal(receipt.decision, "request-changes");
+  assert.match(receipt.findings.join(" "), /does not belong to this pull request/);
+});
+
+test("a review receipt naming a preview is still safe to post publicly", () => {
+  const receipt = reviewPull({
+    ...owner,
+    ...okProof,
+    head: HEAD,
+    preview: { url: url(144), status: 200, version: HEAD },
+  });
+  assert.doesNotThrow(() => formatReviewComment(receipt), "the receipt must not leak the private host");
+  const comment = formatReviewComment(receipt);
+  assert.ok(!/cloudflare\.dev/.test(comment), "a public comment must not name the private install");
+  assert.match(comment, /verified against the live preview/);
+});
+
+test("every preview failure message is safe to post publicly", () => {
+  const cases: PreviewCheck[] = [
+    { url: url(999), status: 200, version: HEAD },
+    { url: url(144), status: 502, version: HEAD },
+    { url: url(144), status: 200, version: "9999999aaaa" },
+    { url: url(144), status: 200 },
+  ];
+  for (const preview of cases) {
+    const receipt = reviewPull({ ...owner, ...okProof, head: HEAD, preview });
+    assert.equal(receipt.decision, "request-changes");
+    assert.doesNotThrow(() => formatReviewComment(receipt), `must not leak: ${JSON.stringify(preview)}`);
+  }
+});

--- a/agents/src/preview-check.ts
+++ b/agents/src/preview-check.ts
@@ -1,0 +1,63 @@
+export const DEFAULT_PREVIEW_HOST_SUFFIX = "";
+
+function hostSuffix(): string {
+  const configured = (globalThis as { PREVIEW_HOST_SUFFIX?: string }).PREVIEW_HOST_SUFFIX;
+  return typeof configured === "string" && configured !== "" ? configured : DEFAULT_PREVIEW_HOST_SUFFIX;
+}
+
+export function previewHostForPull(pullNumber: number, suffix = hostSuffix()): string {
+  if (!Number.isInteger(pullNumber) || pullNumber <= 0) {
+    throw new Error("a preview host needs a positive pull number");
+  }
+  if (!suffix) throw new Error("the preview host suffix is not configured");
+  return `pr-${pullNumber}${suffix}`;
+}
+
+export interface PreviewCheck {
+  url: string;
+  status: number;
+  version?: string;
+}
+
+export function previewUrlForPull(pullNumber: number, suffix = hostSuffix()): string {
+  return `https://${previewHostForPull(pullNumber, suffix)}`;
+}
+
+export function isPreviewUrlForPull(url: string, pullNumber: number, suffix = hostSuffix()): boolean {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "https:") return false;
+    return parsed.hostname === previewHostForPull(pullNumber, suffix);
+  } catch {
+    return false;
+  }
+}
+
+export function previewFindings(
+  input: { number?: number; head?: string; preview?: PreviewCheck },
+  suffix = hostSuffix(),
+): { ok: boolean; findings: string[] } {
+  const pullNumber = input.number ?? 0;
+  const preview = input.preview;
+
+  if (!preview) {
+    return { ok: false, findings: ["preview missing; deploy the head to its preview host and re-check"] };
+  }
+  if (!isPreviewUrlForPull(preview.url, pullNumber, suffix)) {
+    return { ok: false, findings: [`preview URL does not belong to this pull request: expected the pr-${pullNumber} preview host`] };
+  }
+  if (preview.status !== 200) {
+    return { ok: false, findings: [`preview did not answer 200 (got ${preview.status})`] };
+  }
+  if (!preview.version) {
+    return { ok: false, findings: ["the preview did not report a deployed version"] };
+  }
+  if (!input.head) {
+    return { ok: false, findings: ["cannot confirm the preview runs this head; head is unknown"] };
+  }
+  if (!preview.version.startsWith(input.head.slice(0, 7))) {
+    return { ok: false, findings: [`the preview runs ${preview.version.slice(0, 7)}, not this head`] };
+  }
+
+  return { ok: true, findings: [`verified against the live preview for this pull request, running ${preview.version.slice(0, 7)}`] };
+}

--- a/agents/src/review.test.ts
+++ b/agents/src/review.test.ts
@@ -83,12 +83,16 @@ test("failed proof requests changes and never approves", async () => {
   assert.match(formatReviewComment(receipt), /neverApprove: true/);
 });
 
-test("passing owner proof is ready for owner, not approved", async () => {
+test("passing owner proof with a verified preview is ready for owner, not approved", async () => {
   const receipt = reviewPull(pull({
+    number: 144,
+    head: "deadbeefcafe",
     title: "fix: junk URL",
     body: "proof",
     proofExit: 0,
     proofLog: "# pass 18\n> tsc --noEmit\n",
+    previewHostSuffix: ".preview.example",
+    preview: { url: "https://pr-144.preview.example", status: 200, version: "deadbeefcafe" },
   }));
   assert.equal(receipt.decision, "ready-for-owner");
   assert.equal(receipt.neverApprove, true);

--- a/agents/src/review.ts
+++ b/agents/src/review.ts
@@ -1,5 +1,6 @@
 import { assertNoMergeAction, type PullInput } from "./policy";
 import { assertPublicText } from "./public-text";
+import { previewFindings, type PreviewCheck } from "./preview-check";
 import type { GithubPort } from "./orchestrate";
 
 export const OWNER_LOGINS = ["acoyfellow"] as const;
@@ -20,7 +21,9 @@ export function isOwnerPr(input: { author: string; head?: string }): boolean {
   return Boolean(input.head && OWNER_HEAD.test(input.head));
 }
 
-export function reviewPull(input: PullInput & { head?: string; proofExit?: number; proofLog?: string }): ReviewReceipt {
+export type ReviewInput = PullInput & { head?: string; proofExit?: number; proofLog?: string; preview?: PreviewCheck; previewHostSuffix?: string };
+
+export function reviewPull(input: ReviewInput): ReviewReceipt {
   if (!isOwnerPr({ author: input.author, head: input.head })) {
     return { decision: "ignore", neverApprove: true, neverMerge: true, findings: ["not an owner PR"] };
   }
@@ -55,11 +58,20 @@ export function reviewPull(input: PullInput & { head?: string; proofExit?: numbe
       findings: ["proof log has no typecheck or test pass line"],
     };
   }
+  const preview = input.previewHostSuffix ? previewFindings(input, input.previewHostSuffix) : previewFindings(input);
+  if (!preview.ok) {
+    return {
+      decision: "request-changes",
+      neverApprove: true,
+      neverMerge: true,
+      findings: preview.findings,
+    };
+  }
   return {
     decision: "ready-for-owner",
     neverApprove: true,
     neverMerge: true,
-    findings: ["proof passed; owner is the last reviewer"],
+    findings: ["proof passed; owner is the last reviewer", ...preview.findings],
   };
 }
 
@@ -74,7 +86,7 @@ export function formatReviewComment(receipt: ReviewReceipt): string {
 }
 
 export async function runReview(
-  input: PullInput & { head?: string; proofExit?: number; proofLog?: string },
+  input: ReviewInput,
   ports: { github: GithubPort },
 ): Promise<ReviewReceipt> {
   const receipt = reviewPull(input);

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "test:dead-session-scan": "tsx --test src/dead-session-scan.test.ts",
     "test:memory-block": "tsx --test src/memory-block.test.ts",
     "test:notify": "tsx --test src/notify.test.ts",
-    "test:lifecycle-agents": "tsx --test agents/src/policy.test.ts agents/src/harness.test.ts agents/src/github-hmac.test.ts agents/src/sweep.test.ts agents/src/review.test.ts agents/src/docs-drift.test.ts",
+    "test:lifecycle-agents": "tsx --test agents/src/policy.test.ts agents/src/harness.test.ts agents/src/github-hmac.test.ts agents/src/sweep.test.ts agents/src/review.test.ts agents/src/preview-check.test.ts agents/src/docs-drift.test.ts",
     "test:push-decision-actions": "tsx --test src/push-decision-actions.test.ts",
     "test:sw-decision-click": "tsx --test src/sw-decision-click.test.ts",
     "test:push-progress-tag": "tsx --test src/push-progress-tag.test.ts",


### PR DESCRIPTION
## Why

A review receipt said the proof passed. That is a claim about source. Nothing checked
whether a running deployment of that head actually worked, so a review could pass on
code that fails the moment it is deployed.

## What changed

`reviewPull` now requires a preview check before it will say `ready-for-owner`. It
fails closed exactly like a missing proof does. Any of these requests changes:

- no preview at all
- the preview answered something other than 200
- the preview reported no deployed version
- the preview runs a version that is not this head
- the preview URL belongs to a **different pull request**

That last one matters: without it, one PR could borrow another PR's passing deploy.

## Public text

The first version of this put the preview URL in the receipt. The pre-commit
guardrail and `assertPublicText` both rejected it, correctly, because a review
comment is public and the host is a private install.

Rather than weaken either guard, the host suffix is now injected instead of
hardcoded, and the receipt says a live preview was verified without naming it. Two
tests assert that a receipt is safe to post, including every failure message. No file
in this PR contains the private hostname, and the tests run against
`.preview.example`.

## Proof

```
agents/src/preview-check.test.ts   12 pass
agents/src/review.test.ts           7 pass
npm run check                       exit 0
```

Mutation-verified: deleting the fail-closed branch from `reviewPull` gives
`pass 8 fail 2`.

One existing test changed. `passing owner proof is ready for owner` asserted the old
behavior; its real invariant is *passing proof means ready-for-owner, never approved*,
which is preserved. It now supplies a verified preview.

## Not yet live

The preview host suffix is unset by default, so `previewFindings` reports a missing
preview until the deploy path is wired. That is intentional: fail closed. Blocked on
the wildcard Access application in #146.