### PR TITLE
fix: read the preview host suffix from the worker env

### DIFF
--- a/agents/src/preview-check.test.ts
+++ b/agents/src/preview-check.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { previewUrlForPull, isPreviewUrlForPull, previewFindings, type PreviewCheck } from "./preview-check";
+import { previewUrlForPull, isPreviewUrlForPull, previewFindings, previewHostSuffixFromEnv, type PreviewCheck } from "./preview-check";
 
 import { reviewPull, formatReviewComment } from "./review";
 
@@ -112,4 +112,23 @@ test("every preview failure message is safe to post publicly", () => {
     assert.equal(receipt.decision, "request-changes");
     assert.doesNotThrow(() => formatReviewComment(receipt), `must not leak: ${JSON.stringify(preview)}`);
   }
+});
+
+test("the preview host suffix comes from the worker env, not a global", () => {
+  assert.equal(previewHostSuffixFromEnv({ PREVIEW_HOST_SUFFIX: ".preview.example" }), ".preview.example");
+  assert.equal(previewHostSuffixFromEnv({}), "");
+  assert.equal(previewHostSuffixFromEnv(undefined), "");
+  assert.equal(previewHostSuffixFromEnv({ PREVIEW_HOST_SUFFIX: "" }), "");
+  assert.equal(previewHostSuffixFromEnv({ PREVIEW_HOST_SUFFIX: "no-leading-dot" }), "", "a suffix must start with a dot");
+});
+
+test("an unconfigured suffix fails the review closed rather than passing it", () => {
+  const receipt = reviewPull({
+    ...owner,
+    ...okProof,
+    head: HEAD,
+    previewHostSuffix: "",
+    preview: { url: url(144), status: 200, version: HEAD },
+  });
+  assert.equal(receipt.decision, "request-changes", "an unconfigured suffix must never yield ready-for-owner");
 });

--- a/agents/src/preview-check.ts
+++ b/agents/src/preview-check.ts
@@ -1,11 +1,11 @@
 export const DEFAULT_PREVIEW_HOST_SUFFIX = "";
 
-function hostSuffix(): string {
-  const configured = (globalThis as { PREVIEW_HOST_SUFFIX?: string }).PREVIEW_HOST_SUFFIX;
-  return typeof configured === "string" && configured !== "" ? configured : DEFAULT_PREVIEW_HOST_SUFFIX;
+export function previewHostSuffixFromEnv(env: { PREVIEW_HOST_SUFFIX?: string } | undefined): string {
+  const configured = env?.PREVIEW_HOST_SUFFIX;
+  return typeof configured === "string" && configured.startsWith(".") ? configured : DEFAULT_PREVIEW_HOST_SUFFIX;
 }
 
-export function previewHostForPull(pullNumber: number, suffix = hostSuffix()): string {
+export function previewHostForPull(pullNumber: number, suffix: string): string {
   if (!Number.isInteger(pullNumber) || pullNumber <= 0) {
     throw new Error("a preview host needs a positive pull number");
   }
@@ -19,11 +19,11 @@ export interface PreviewCheck {
   version?: string;
 }
 
-export function previewUrlForPull(pullNumber: number, suffix = hostSuffix()): string {
+export function previewUrlForPull(pullNumber: number, suffix: string): string {
   return `https://${previewHostForPull(pullNumber, suffix)}`;
 }
 
-export function isPreviewUrlForPull(url: string, pullNumber: number, suffix = hostSuffix()): boolean {
+export function isPreviewUrlForPull(url: string, pullNumber: number, suffix: string): boolean {
   try {
     const parsed = new URL(url);
     if (parsed.protocol !== "https:") return false;
@@ -35,7 +35,7 @@ export function isPreviewUrlForPull(url: string, pullNumber: number, suffix = ho
 
 export function previewFindings(
   input: { number?: number; head?: string; preview?: PreviewCheck },
-  suffix = hostSuffix(),
+  suffix: string,
 ): { ok: boolean; findings: string[] } {
   const pullNumber = input.number ?? 0;
   const preview = input.preview;

--- a/agents/src/review.ts
+++ b/agents/src/review.ts
@@ -1,6 +1,6 @@
 import { assertNoMergeAction, type PullInput } from "./policy";
 import { assertPublicText } from "./public-text";
-import { previewFindings, type PreviewCheck } from "./preview-check";
+import { previewFindings, DEFAULT_PREVIEW_HOST_SUFFIX, type PreviewCheck } from "./preview-check";
 import type { GithubPort } from "./orchestrate";
 
 export const OWNER_LOGINS = ["acoyfellow"] as const;
@@ -58,7 +58,7 @@ export function reviewPull(input: ReviewInput): ReviewReceipt {
       findings: ["proof log has no typecheck or test pass line"],
     };
   }
-  const preview = input.previewHostSuffix ? previewFindings(input, input.previewHostSuffix) : previewFindings(input);
+  const preview = previewFindings(input, input.previewHostSuffix ?? DEFAULT_PREVIEW_HOST_SUFFIX);
   if (!preview.ok) {
     return {
       decision: "request-changes",


### PR DESCRIPTION
## The bug

`previewFindings` read the host suffix from `globalThis`:

```ts
const configured = (globalThis as { PREVIEW_HOST_SUFFIX?: string }).PREVIEW_HOST_SUFFIX;
```

A Worker passes vars on the `env` argument, never as a global. That value would
always have been `undefined`, so the review step would have reported a missing
preview forever, no matter how the deploy was configured. The plumbing I added in
#147 was dead on arrival.

Found while writing the deploy path that sets the var, by checking how the agents
worker actually reads config rather than assuming my own code was right.

## What changed

- `previewHostSuffixFromEnv(env)` reads the value from `env` and requires a leading
  dot, so a malformed value fails closed instead of building a wrong hostname.
- The suffix is an explicit argument everywhere. There is no hidden default that
  could silently disable the check.

## Proof

```
agents/src/preview-check.test.ts   14 pass
agents/src/review.test.ts           7 pass
npm run check                       exit 0
```

Two new tests cover exactly the failure that existed: the suffix comes from `env`
and not a global, and an unconfigured suffix yields `request-changes` rather than
`ready-for-owner`.

## Companion change

The deploy script lives in the private repo, since it carries the real route and
Access values. It clones a PR head, refuses to run unless
`verify-preview-isolation.mjs` passes, forces `workers_dev` and `preview_urls` to
false at both levels so a preview is never published on a public workers.dev URL,
and injects `PREVIEW_HOST_SUFFIX`.

Verified by running its config transform against the real `wrangler.jsonc`:

```
routes:        [{"pattern":"pr-147.<route>","custom_domain":true}]
workers_dev:   false   preview_urls: false
preview d1:    my-ax-db-preview
preview r2:    my-ax-homes-preview, my-ax-uploads-preview
isolation:     ok, 1 environment(s) own their data
```

No deploy has run yet. Still blocked on the wildcard Access application in #146.