### PR TITLE
test: gate proving a review checked a real preview deploy

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -33,6 +33,7 @@ bash proof/factory-no-loop.sh   # one pr-opened board, no stage regression, at m
                                 # review receipt, 0 open issues, 0 open PRs, check green
 bash proof/error-queue-drained.sh  # no open auto-error issue predates the running deploy
 bash proof/agentcast-live.sh       # the live browser opens, instructs, and returns a redacted receipt
+bash proof/preview-per-pr.sh       # an open PR has an isolated preview behind Access, running its own head
 ```
 
 `factory-no-loop.sh` waits past two 15 minute sweeps on purpose. The re-queue bug it guards only appears across sweep ticks.
@@ -40,6 +41,8 @@ bash proof/agentcast-live.sh       # the live browser opens, instructs, and retu
 `error-queue-drained.sh` compares each open auto-error issue against the deploy time of the running Worker. A merged but undeployed fix looks exactly like a broken fix, so the gate reads the live deploy rather than `main`.
 
 `agentcast-live.sh` calls the real service and needs `AGENTCAST_ISSUER_KEY`, so it is opt-in and never runs in CI. It stops every session it opens, including on failure, because a gate that leaks browser capacity is a broken gate.
+
+`preview-per-pr.sh` proves a review is evidence about deployed code. It requires that an unauthenticated request to the preview host is refused, that the host answers 200 through Access, that the deployed commit is that PR head, that the preview database is not the production database, and that the PR carries a review receipt saying it verified a live preview. It needs an Access token, so it is opt-in and never runs in CI.
 
 Hunt ticks that only file issues: [HUNT.md](./HUNT.md).
 

--- a/proof/preview-per-pr.sh
+++ b/proof/preview-per-pr.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${PREVIEW_ENV_FILE:-$(cd "$ROOT/.." && pwd)/my-ax-private/employee.env}"
+if [ -z "${EMPLOYEE_ROUTE:-}" ] && [ -r "$ENV_FILE" ]; then
+  EMPLOYEE_ROUTE="$(sed -n 's/^EMPLOYEE_ROUTE=//p' "$ENV_FILE" | tail -1)"
+fi
+
+ROUTE="${EMPLOYEE_ROUTE:-}"
+PR="${PR:-}"
+
+log() { printf '[preview] %s\n' "$*" >&2; }
+fail() { printf '[preview][FAIL] %s\n' "$*" >&2; exit 1; }
+
+[ -n "$ROUTE" ] || fail "EMPLOYEE_ROUTE is required; export it or put it in $ENV_FILE"
+command -v jq >/dev/null || fail "jq is required"
+command -v gh >/dev/null || fail "gh is required"
+command -v cloudflared >/dev/null || fail "cloudflared is required to reach an Access protected host"
+
+if [ -z "$PR" ]; then
+  PR="$(gh pr list --state open --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+  [ -n "$PR" ] || fail "no open pull request to verify; open one or set PR=<number>"
+fi
+case "$PR" in ''|*[!0-9]*) fail "PR must be a positive integer" ;; esac
+
+HOST="pr-${PR}.${ROUTE}"
+BASE="https://$HOST"
+log "verifying PR #$PR against its own preview deploy"
+
+HEAD_SHA="$(gh pr view "$PR" --json headRefOid --jq .headRefOid 2>/dev/null || true)"
+[ -n "$HEAD_SHA" ] || fail "cannot read the head SHA for PR #$PR"
+log "PR #$PR head is ${HEAD_SHA:0:7}"
+
+if ! dig +short "$HOST" | head -1 | grep -q .; then
+  fail "$HOST does not resolve; deploy the PR head with deploy-preview.sh first"
+fi
+
+UNAUTH="$(curl -s -o /dev/null -w '%{http_code}' "$BASE/api/health" --max-time 30 || true)"
+case "$UNAUTH" in
+  200) fail "$HOST served an unauthenticated request; a preview must sit behind Access" ;;
+  000) fail "$HOST did not answer at all" ;;
+  *) log "PROVEN: an unauthenticated request is refused ($UNAUTH)" ;;
+esac
+
+TOKEN="$(cloudflared access token --app "$BASE" 2>/dev/null | tail -1 || true)"
+[ -n "$TOKEN" ] && [ "${#TOKEN}" -gt 40 ] || fail "no Access token for $BASE; run: cloudflared access login $BASE"
+
+CODE="$(curl -s -o /dev/null -w '%{http_code}' "$BASE/api/health" -H "cf-access-token: $TOKEN" --max-time 40 || true)"
+[ "$CODE" = "200" ] || fail "$HOST answered $CODE through Access, not 200"
+log "PROVEN: the preview answers 200 through Access"
+
+SYSTEM="$(curl -s "$BASE/api/system" -H "cf-access-token: $TOKEN" --max-time 40 || true)"
+DEPLOYED="$(printf '%s' "$SYSTEM" | jq -r '.deploy.commit // .commit // .version // empty' 2>/dev/null || true)"
+[ -n "$DEPLOYED" ] || fail "the preview did not report a deployed commit"
+case "$HEAD_SHA" in
+  "$DEPLOYED"*) log "PROVEN: the preview runs this PR head (${DEPLOYED:0:7})" ;;
+  *) case "$DEPLOYED" in
+       "${HEAD_SHA:0:7}"*) log "PROVEN: the preview runs this PR head (${DEPLOYED:0:7})" ;;
+       *) fail "the preview runs ${DEPLOYED:0:7} but PR #$PR head is ${HEAD_SHA:0:7}" ;;
+     esac ;;
+esac
+
+node "$ROOT/scripts/verify-preview-isolation.mjs" preview >/dev/null 2>&1 \
+  || fail "env.preview is not isolated from production data"
+PROD_DB="$(node -e '
+const {parse}=require("jsonc-parser");
+const c=parse(require("fs").readFileSync(process.argv[1],"utf8"),[],{allowTrailingComma:true});
+process.stdout.write((c.d1_databases||[]).map(d=>d.database_name).join(","));
+' "$ROOT/wrangler.jsonc")"
+PREVIEW_DB="$(node -e '
+const {parse}=require("jsonc-parser");
+const c=parse(require("fs").readFileSync(process.argv[1],"utf8"),[],{allowTrailingComma:true});
+process.stdout.write((c.env.preview.d1_databases||[]).map(d=>d.database_name).join(","));
+' "$ROOT/wrangler.jsonc")"
+[ -n "$PREVIEW_DB" ] || fail "env.preview declares no database"
+[ "$PROD_DB" != "$PREVIEW_DB" ] || fail "the preview database is the production database ($PROD_DB)"
+log "PROVEN: the preview owns its data, separate from production"
+
+RECEIPT="$(gh pr view "$PR" --json comments --jq '[.comments[].body | select(test("review receipt"))] | last // empty' 2>/dev/null || true)"
+[ -n "$RECEIPT" ] || fail "PR #$PR has no factory review receipt yet"
+printf '%s' "$RECEIPT" | grep -qi 'verified against the live preview' \
+  || fail "the review receipt does not say it verified a live preview"
+printf '%s' "$RECEIPT" | grep -qi 'neverMerge: true' \
+  || fail "the review receipt is missing the never-merge guarantee"
+printf '%s' "$RECEIPT" | grep -qiE 'decision: (ready-for-owner|request-changes)' \
+  || fail "the review receipt has no decision"
+log "PROVEN: the factory review receipt records a live preview verification"
+
+( cd "$ROOT" && npm run check >/dev/null 2>&1 ) || fail "npm run check does not pass"
+log "PROVEN: npm run check exits 0"
+
+printf '\n# pass preview-per-pr: PR #%s has an isolated preview behind Access, running its own head, verified by the factory\n' "$PR"


### PR DESCRIPTION
## Why

The contract for this work had no runnable gate. Everything so far was unit tested
or verified by hand, so nothing could prove the pieces fit together.

## What it asserts

`proof/preview-per-pr.sh` resolves an open PR's preview host and requires all of:

1. An **unauthenticated** request is refused. A 200 here is a failure, because a
   preview host serving anonymous traffic is worse than no preview at all.
2. The host answers 200 **through Access**.
3. The deployed commit equals that PR head, so the review is about this code.
4. The preview database is not the production database.
5. The PR carries a review receipt that says it verified a live preview.

Assertion 5 is the point of the contract. It separates a review that checked
deployed code from one that only read source.

## Proof

Run against real state, it fails closed at the first missing thing and names the fix:

```
[preview] verifying PR #144 against its own preview deploy
[preview] PR #144 head is 434595a
[preview][FAIL] pr-144.<route> does not resolve; deploy the PR head with deploy-preview.sh first
EXIT=1
```

Each later assertion was exercised separately, since the host does not exist yet:

- Isolation, against the real config: `prod db my-ax-db`, `preview db my-ax-db-preview`, differ **true**.
- Receipt matching, against two fixtures: a receipt naming a live preview **passes**;
  a source-only receipt **fails (caught)**.
- End to end, the receipt the factory actually generates was fed to the gate's own
  checks and accepted:

```
## review receipt
decision: ready-for-owner
neverMerge: true
- proof passed; owner is the last reviewer
- verified against the live preview for this pull request, running abc1234

gate would accept: true
```

That last check found a mistake in my first attempt: I omitted `proofExit`, the
review took the fail-closed path, and the gate correctly rejected it. Worth keeping
as evidence the gate is not rubber-stamping.

`npm run check` exits 0, and `docs-drift.test.ts` passes with the gate documented.