### PR TITLE
fix: a declined notification link no longer stalls, and stays same origin

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -146,13 +146,20 @@ async function navigateNotification(href) {
   const existing = sameOrigin.find((client) => client.focused) || sameOrigin.find((client) => client.visibilityState === "visible") || sameOrigin[0];
   const target = new URL(href, self.location.origin);
   const absolute = target.href;
+  const sameOriginTarget = target.origin === self.location.origin;
   if (existing) {
-    if (target.pathname === "/" && !target.search && !target.hash) return existing.focus();
+    if (target.pathname === "/" && !target.search && !target.hash && sameOriginTarget) return existing.focus();
+    if (!sameOriginTarget) return clients.openWindow(absolute);
     const acked = await new Promise((resolve) => {
       const onAck = (ev) => {
-        if (ev.data?.type === "my-ax:navigate-ack" && ev.data?.href === absolute) {
+        if (ev.data?.href !== absolute) return;
+        if (ev.data?.type === "my-ax:navigate-ack") {
           self.removeEventListener("message", onAck);
           resolve(true);
+        }
+        if (ev.data?.type === "my-ax:navigate-nack") {
+          self.removeEventListener("message", onAck);
+          resolve(false);
         }
       };
       self.addEventListener("message", onAck);

--- a/src/ui/Chat.svelte
+++ b/src/ui/Chat.svelte
@@ -2340,6 +2340,10 @@
       const target = detail?.href ? parseMyAxDeepLink(detail.href, location.href) : null;
       if (target) followDeepLink(target);
     };
+    const declineServiceWorkerNavigation = (event: MessageEvent, href: string) => {
+      try { (event.source as any)?.postMessage?.({ type: "my-ax:navigate-nack", href }); } catch {}
+      try { navigator.serviceWorker?.controller?.postMessage({ type: "my-ax:navigate-nack", href }); } catch {}
+    };
     const onServiceWorkerMessage = (event: MessageEvent) => {
       if (event.data?.type === "my-ax:attention") {
         void refreshPendingDecision(localStorage.getItem(SESSION_KEY));
@@ -2354,7 +2358,9 @@
         try { (event.source as any)?.postMessage?.({ type: "my-ax:navigate-ack", href: event.data.href }); } catch {}
         try { navigator.serviceWorker?.controller?.postMessage({ type: "my-ax:navigate-ack", href: event.data.href }); } catch {}
         followDeepLink(target);
+        return;
       }
+      declineServiceWorkerNavigation(event, event.data.href);
     };
     const onStartersRefresh = () => { void loadStarters(); };
     // Artifact -> chat bridge. An interactive Svelte artifact runs in a

--- a/src/ui/sw-navigation-ack.test.ts
+++ b/src/ui/sw-navigation-ack.test.ts
@@ -34,9 +34,14 @@ async function runNotificationClick(
   }
   const acked = await new Promise<boolean>((resolve) => {
     const onAck = (ev: { data: any }) => {
-      if (ev.data?.type === "my-ax:navigate-ack" && ev.data?.href === absolute) {
+      if (ev.data?.href !== absolute) return;
+      if (ev.data?.type === "my-ax:navigate-ack") {
         self.removeEventListener("message", onAck);
         resolve(true);
+      }
+      if (ev.data?.type === "my-ax:navigate-nack") {
+        self.removeEventListener("message", onAck);
+        resolve(false);
       }
     };
     self.addEventListener("message", onAck);
@@ -94,4 +99,36 @@ test("an informational root push focuses the existing client without posting or 
   assert.equal(navigated, 0);
   assert.equal(focused, 1);
   assert.equal(listenerCount(), 0);
+});
+
+test("a declining client does not cost the full ack timeout", async () => {
+  const { self, deliver, listenerCount } = makeSwHarness();
+  let navigated = 0;
+  const href = "https://x/weird";
+  const existing = {
+    postMessage(msg: any) {
+      if (msg.type === "my-ax:navigate") setTimeout(() => deliver({ type: "my-ax:navigate-nack", href: msg.href }), 5);
+    },
+    async navigate() { navigated++; },
+    async focus() {},
+  };
+  const started = Date.now();
+  const acked = await runNotificationClick(self, existing, href, 400);
+  const elapsed = Date.now() - started;
+  assert.equal(acked, false, "a nack is not an ack");
+  assert.equal(navigated, 1, "the SW still falls back to a hard navigate");
+  assert.ok(elapsed < 200, `a declined link must not wait out the timeout, took ${elapsed}ms`);
+  assert.equal(listenerCount(), 0);
+});
+
+test("a cross-origin notification target never reaches an open client", () => {
+  const appOrigin = "https://app.example";
+  const decide = (href: string) => {
+    const target = new URL(href, appOrigin);
+    return target.origin === appOrigin ? "message-client" : "open-window";
+  };
+  assert.equal(decide("/?action=attention"), "message-client");
+  assert.equal(decide("https://app.example/?session=abc"), "message-client");
+  assert.equal(decide("https://github.com/acoyfellow/my-ax/pull/1"), "open-window");
+  assert.equal(decide("https://evil.example/steal"), "open-window");
 });


### PR DESCRIPTION
Two problems in the `notificationclick` path.

## 1. A declined link paid the full timeout

The client acked only when `parseMyAxDeepLink` returned a target. When it returned
`null` the client went **silent**, so the service worker waited its entire 400ms ack
window before falling back to a hard navigate.

The app had already decided it could not handle the link. The delay bought nothing;
it just made a notification tap feel broken.

The client now sends `my-ax:navigate-nack` when it declines, and the SW falls back
immediately.

## 2. A cross-origin target could navigate the open PWA

The SW resolved the href against its own origin but never checked the result:

```js
const target = new URL(href, self.location.origin);
// ...
if (!acked) await existing.navigate(absolute);
```

Line 145 filters *client* origins. Nothing filtered the *target*. And this is not
hypothetical: `notify.ts:226` deliberately allows `github.com` and
`gitlab.cfdata.org` hrefs, so cross-origin targets genuinely occur. The client
correctly refuses them, which meant they took the silent path above and then got
hard-navigated anyway, taking the PWA off origin.

A cross-origin target is now an `openWindow` case: it is never messaged to an
existing client and never used to navigate one.

## Proof

```
src/ui/sw-navigation-ack.test.ts   5 pass
npm run check                      exit 0
```

The timing test measures the real cost. Mutation-verified by removing nack handling:

```
AssertionError: a declined link must not wait out the timeout, took 401ms
pass 4 fail 1
```

401ms without the fix, under 200ms with it.

The pre-commit hook rejected my explanatory comment, so the decline path is now a
named `declineServiceWorkerNavigation` helper instead of a comment.