### PR TITLE
fix: session names stay short; factory receipts are not product

### DIFF
--- a/agents/src/orchestrate.ts
+++ b/agents/src/orchestrate.ts
@@ -57,7 +57,12 @@ export type TriageStep =
   | { step: "stop"; reason: string };
 
 export function productFilesOnBranch(files: string[]): string[] {
-  return files.filter((file) => file.length > 0 && !file.startsWith(".factory/"));
+  return files.filter((file) => {
+    if (!file.length) return false;
+    if (file.startsWith(".factory/")) return false;
+    if (/^src\/factory\/issue-\d+\.md$/.test(file)) return false;
+    return file.startsWith("src/");
+  });
 }
 
 export function factoryReceiptPath(issueNumber: number): string {

--- a/agents/src/policy.test.ts
+++ b/agents/src/policy.test.ts
@@ -160,7 +160,7 @@ test("an opted-in draft does not open a ready PR when putFile is missing and the
   assert.ok(!github.actions.some((action) => action.startsWith("pr:")));
 });
 
-test("an opted-in draft writes a src receipt then opens a ready PR", async () => {
+test("an opted-in draft does not open a ready PR when putFile only writes a factory receipt", async () => {
   const github = memoryGithub();
   const files = [".factory/issue-40.md"];
   github.hasBranch = async () => true;
@@ -171,7 +171,8 @@ test("an opted-in draft writes a src receipt then opens a ready PR", async () =>
     { github, terrarium: memoryTerrarium(true), model: { modelId: "grok-4.6" } },
   );
   assert.ok(github.actions.some((action) => action.startsWith("putFile:src/factory/issue-40.md")));
-  assert.ok(steps.some((s) => s.step === "pr" && s.number === 7));
+  assert.ok(steps.some((s) => s.step === "stop" && String(s.reason).includes("product files missing")));
+  assert.ok(!github.actions.some((action) => action.startsWith("pr:")));
   assert.ok(!github.actions.some((action) => action.includes("terrarium")));
 });
 

--- a/proof/factory-implements.sh
+++ b/proof/factory-implements.sh
@@ -17,16 +17,35 @@ grep -n 'formatImplementTask\|IMPLEMENT_TASK_PROOF' agents/src/orchestrate.ts >/
   && fail "draft still has a Terrarium implementer"
 echo "ok: no Terrarium on draft"
 
-echo "== 3. live: an open PR has a product file =="
+is_product_path() {
+  case "$1" in
+    .factory/*) return 1 ;;
+    src/factory/issue-*.md) return 1 ;;
+    src/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+echo "== 3. planted: receipt markdown is not a product file =="
+is_product_path "src/factory/issue-155.md" && fail "src/factory/issue-155.md must not count as product"
+is_product_path ".factory/issue-155.md" && fail ".factory/ stamp must not count as product"
+is_product_path "src/ui/Chat.svelte" || fail "a real src/ path must count as product"
+echo "ok: receipt markdown is not product"
+
+echo "== 4. live: an open PR has a real product file =="
 PRODUCT_PR=""
 for PR in $(gh pr list --repo acoyfellow/my-ax --state open --limit 30 --json number --jq '.[].number'); do
   FILES="$(gh pr view "$PR" --repo acoyfellow/my-ax --json files --jq '[.files[].path] | join("\n")')"
-  if printf '%s\n' "$FILES" | grep -qv '^\.factory/'; then
-    PRODUCT_PR="$PR"
-    break
-  fi
+  while IFS= read -r path; do
+    [ -z "$path" ] && continue
+    if is_product_path "$path"; then
+      PRODUCT_PR="$PR"
+      break
+    fi
+  done <<< "$FILES"
+  [ -n "$PRODUCT_PR" ] && break
 done
-[ -n "$PRODUCT_PR" ] || fail "no open PR has a non-.factory product file"
+[ -n "$PRODUCT_PR" ] || fail "no open PR diffs a real src/ product path (src/factory/issue-*.md does not count)"
 echo "ok: PR $PRODUCT_PR has product files"
 
 echo

--- a/src/session-title.test.ts
+++ b/src/session-title.test.ts
@@ -5,7 +5,7 @@ import { SCHEDULED_JOB_RUN_PREFIX } from "./jobs";
 
 test("scheduled job guard prefix is stripped from session and notification titles", () => {
   const title = deriveSessionTitle(`${SCHEDULED_JOB_RUN_PREFIX}\n\nEvery 5 minutes, check on the Lee cmux PR exchange and ALWAYS notify.`);
-  assert.equal(title, "Every 5 minutes, check on the Lee cmux PR exchange and ALWAYS notify.");
+  assert.equal(title, "Every 5 minutes, check on the Lee cmux PR exchange and ALWAY");
 });
 
 test("normal title derivation still strips code blocks and compresses whitespace", () => {
@@ -13,8 +13,14 @@ test("normal title derivation still strips code blocks and compresses whitespace
   assert.equal(title, "Here is code: Then explain the result.");
 });
 
+test("a session name is never longer than 60 characters", () => {
+  const title = deriveSessionTitle("Look at the attached image. Name its single fill color in one word. Then keep going.");
+  assert.ok(title.length <= 60);
+  assert.equal(title, "Look at the attached image. Name its single fill color in on");
+});
+
 test("title truncation never splits a supplementary character into a lone surrogate", () => {
-  const title = deriveSessionTitle("a".repeat(199) + "😀tail");
-  assert.equal(title, "a".repeat(199) + "😀");
+  const title = deriveSessionTitle("a".repeat(59) + "😀tail");
+  assert.equal(title, "a".repeat(59) + "😀");
   assert.equal(/[\uD800-\uDBFF]$/.test(title), false, "must not end on a dangling high surrogate");
 });

--- a/src/session-title.ts
+++ b/src/session-title.ts
@@ -13,5 +13,5 @@ export function deriveSessionTitle(content: string): string {
   // Truncate by Unicode code points, not UTF-16 code units, so a supplementary
   // character (e.g. an emoji) straddling the 200 boundary is never split into a
   // lone surrogate that renders as �.
-  return Array.from(cleaned).slice(0, 200).join("");
+  return Array.from(cleaned).slice(0, 60).join("");
 }


### PR DESCRIPTION
## Why
Issue #155: session list names were the first prompt. Factory treated `src/factory/issue-N.md` as a product file.

## What
- `deriveSessionTitle` caps at 60 characters.
- `productFilesOnBranch` ignores `.factory/` and `src/factory/issue-*.md`.
- Proof `factory-implements.sh` planted check fails a receipt-as-product.

Worker never merges or approves.

Closes #155