### PR TITLE
feat: upgrade GLM to 5.3 and remove GPT-5.5

### DIFF
--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -22,8 +22,9 @@ describe("model catalog", () => {
   });
   it("keeps Workers AI and AI Gateway rows in the full catalog", () => {
     assert.ok(findModel("@cf/moonshotai/kimi-k2.7-code"));
-    assert.ok(findModel("@cf/zai-org/glm-5.2"));
-    assert.equal(findModel("gpt-5.5")?.route, "gateway-openai");
+    assert.equal(findModel("@cf/zai-org/glm-5.3")?.context, 1_310_720);
+    assert.equal(findModel("@cf/zai-org/glm-5.2"), undefined);
+    assert.equal(findModel("gpt-5.5"), undefined);
     assert.equal(findModel("gpt-5.6-luna")?.route, "gateway-openai");
     assert.equal(findModel("gpt-5.6-sol")?.route, "gateway-openai");
     assert.equal(findModel("gpt-5.6-terra")?.route, "gateway-openai");
@@ -33,9 +34,16 @@ describe("model catalog", () => {
   });
 
   it("shows gateway rows only when the installation has gateway config", () => {
-    assert.deepEqual(availableModels(minimalEnv).map((m) => m.id), ["@cf/moonshotai/kimi-k2.7-code", "@cf/zai-org/glm-5.2"]);
-    assert.deepEqual(availableModels(gatewayEnv).map((m) => m.id), ["@cf/moonshotai/kimi-k2.7-code", "@cf/zai-org/glm-5.2", "claude-opus-5", "claude-opus-4-8", "gpt-5.5", "gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra"]);
+    assert.deepEqual(availableModels(minimalEnv).map((m) => m.id), ["@cf/moonshotai/kimi-k2.7-code", "@cf/zai-org/glm-5.3"]);
+    assert.deepEqual(availableModels(gatewayEnv).map((m) => m.id), ["@cf/moonshotai/kimi-k2.7-code", "@cf/zai-org/glm-5.3", "claude-opus-5", "claude-opus-4-8", "gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra"]);
     assert.deepEqual(availableModels(serviceGatewayEnv).map((m) => m.id), availableModels(gatewayEnv).map((m) => m.id));
+  });
+
+  it("migrates saved GLM 5.2 selections to GLM 5.3", () => {
+    assert.equal(resolveModelId("@cf/zai-org/glm-5.2"), "@cf/zai-org/glm-5.3");
+    for (const env of [minimalEnv, gatewayEnv, serviceGatewayEnv]) {
+      assert.equal(resolveAvailableModelId(env, "@cf/zai-org/glm-5.2"), "@cf/zai-org/glm-5.3");
+    }
   });
 
   it("removes alpha rows while healing stale alpha ids", () => {
@@ -47,7 +55,7 @@ describe("model catalog", () => {
   it("uses a visible default and preserves valid gateway ids", () => {
     assert.ok(findModel(DEFAULT_MODEL_ID));
     assert.equal(resolveModelId(undefined), DEFAULT_MODEL_ID);
-    assert.equal(resolveModelId("gpt-5.5"), "gpt-5.5");
+    assert.equal(resolveModelId("gpt-5.5"), DEFAULT_MODEL_ID);
     assert.equal(resolveModelId("gpt-5.6-luna"), "gpt-5.6-luna");
     assert.equal(resolveModelId("gpt-5.6-sol"), "gpt-5.6-sol");
     assert.equal(resolveModelId("gpt-5.6-terra"), "gpt-5.6-terra");
@@ -62,7 +70,7 @@ describe("model catalog", () => {
     assert.equal(resolveAvailableModelId(minimalEnv, "claude-opus-5"), DEFAULT_MODEL_ID);
     assert.equal(resolveAvailableModelId(minimalEnv, "claude-opus-4-8"), DEFAULT_MODEL_ID);
     assert.equal(resolveAvailableModelId(gatewayEnv, "claude-opus-5"), "claude-opus-5");
-    assert.equal(resolveAvailableModelId(gatewayEnv, "gpt-5.5"), "gpt-5.5");
+    assert.equal(resolveAvailableModelId(gatewayEnv, "gpt-5.5"), DEFAULT_GATEWAY_MODEL_ID);
     assert.equal(resolveAvailableModelId(gatewayEnv, "gpt-5.6-luna"), "gpt-5.6-luna");
     assert.equal(resolveAvailableModelId(gatewayEnv, "gpt-5.6-sol"), "gpt-5.6-sol");
     assert.equal(resolveAvailableModelId(gatewayEnv, "gpt-5.6-terra"), "gpt-5.6-terra");

--- a/src/models.ts
+++ b/src/models.ts
@@ -56,14 +56,14 @@ export const MODELS: ModelEntry[] = [
     label: "Kimi K2.7 Code",
   },
   {
-    id: "@cf/zai-org/glm-5.2",
+    id: "@cf/zai-org/glm-5.3",
     route: "workers-ai",
     owned_by: "zai",
-    context: 262_144,
+    context: 1_310_720,
     reasoning: true,
     tools: true,
     vision: false,
-    label: "GLM 5.2",
+    label: "GLM 5.3",
   },
   {
     id: "claude-opus-5",
@@ -84,16 +84,6 @@ export const MODELS: ModelEntry[] = [
     tools: true,
     vision: true,
     label: "Opus 4.8",
-  },
-  {
-    id: "gpt-5.5",
-    route: "gateway-openai",
-    owned_by: "openai",
-    context: 400_000,
-    reasoning: true,
-    tools: true,
-    vision: true,
-    label: "GPT-5.5",
   },
   {
     id: "gpt-5.6-luna",
@@ -177,8 +167,13 @@ export function findModel(id: string): ModelEntry | undefined {
 /** Resolve a requested model id to a usable catalog entry. A stale or removed
  * id (e.g. a churned alpha model still pinned in a session/Settings) heals to
  * the default instead of hard-failing every turn with model_not_found. */
+function currentModelId(id: string | undefined): string | undefined {
+  return id === "@cf/zai-org/glm-5.2" ? "@cf/zai-org/glm-5.3" : id;
+}
+
 export function resolveModelId(id: string | undefined): string {
-  return id && findModel(id) ? id : DEFAULT_MODEL_ID;
+  const current = currentModelId(id);
+  return current && findModel(current) ? current : DEFAULT_MODEL_ID;
 }
 
 /** Resolve a model id against the models this installation can actually run.
@@ -186,7 +181,8 @@ export function resolveModelId(id: string | undefined): string {
  * otherwise every turn fails with a provider configuration error even though
  * the visible catalog correctly hides that model. */
 export function resolveAvailableModelId(env: Env, id: string | undefined): string {
-  const requested = id && findModel(id);
+  const current = currentModelId(id);
+  const requested = current && findModel(current);
   if (!requested) return defaultModelId(env);
   return availableModels(env).some((model) => model.id === requested.id) ? requested.id : defaultModelId(env);
 }


### PR DESCRIPTION
Replace GLM 5.2 with the verified Workers AI GLM 5.3 model and its catalog-reported context window. Saved GLM 5.2 selections resolve to GLM 5.3. Remove GPT-5.5; stale selections use the existing installation-specific fallback.

Kimi K3 was not found in the live Workers AI catalog, so Kimi K2.7 remains until its replacement endpoint is verified.

Proof: 15 model tests pass; typecheck passes. Stacked on #222 to preserve the conversation repair and already-green stabilization changes. Production validation pending.