### PR TITLE
fix: keep speech recognition alive for the next voice turn

### DIFF
--- a/src/ui/Chat.svelte
+++ b/src/ui/Chat.svelte
@@ -284,7 +284,6 @@
   // the STT pipeline, then re-arm after a short debounce once playback ends.
   // See ./voice-half-duplex.ts for the pure state machine.
   let voiceGate = initialVoiceGateState();
-  let voiceMicSuppressed = false; // mirrors VoiceClient's internal mute flag
   let voiceRearmTimer: ReturnType<typeof setTimeout> | null = null;
 
   function clearVoiceRearmTimer() {
@@ -294,9 +293,8 @@
   // the desired suppression state differs from the client's actual mute state.
   function setVoiceMicSuppressed(suppressed: boolean) {
     if (!voiceClient) return;
-    if (voiceMicSuppressed === suppressed) return;
-    voiceClient.toggleMute();
-    voiceMicSuppressed = suppressed;
+    voiceTransport?.setInputSuppressed(suppressed);
+    if (voiceClient.isMuted !== suppressed) voiceClient.toggleMute();
   }
   // Fail-closed backstop: never accept a transcript that arrives while the
   // agent is speaking or in the re-arm tail (assistant audio -> user input).
@@ -412,7 +410,6 @@
     voiceTransport = null;
     clearVoiceRearmTimer();
     voiceGate = initialVoiceGateState();
-    voiceMicSuppressed = false;
     prevChimeStatus = "idle";
     transcriptGuard = initialTranscriptGuard();
   }

--- a/src/ui/tapped-voice-transport.test.ts
+++ b/src/ui/tapped-voice-transport.test.ts
@@ -82,6 +82,55 @@ test("tapped transport forwards messages unchanged and meters agent PCM output",
   assert.ok(transport.getOutputLevel() > 0.45);
 });
 
+test("a muted reply keeps recognition fed with silence and resumes real input", (t) => {
+  t.mock.timers.enable({ apis: ["setInterval"] });
+  const { inner, transport } = activeTransport();
+  transport.setInputSuppressed(true);
+  transport.setInputSuppressed(true);
+  t.mock.timers.tick(12_000);
+  assert.equal(inner.sentBinary.length, 120);
+  for (const frame of inner.sentBinary) {
+    assert.equal(frame.byteLength, 3200);
+    assert.ok(new Uint8Array(frame).every((sample) => sample === 0));
+  }
+  transport.setInputSuppressed(false);
+  t.mock.timers.tick(1000);
+  assert.equal(inner.sentBinary.length, 120);
+  const secondTurn = pcm16Frame(12_000);
+  transport.sendBinary(secondTurn);
+  assert.equal(inner.sentBinary.at(-1), secondTurn);
+  transport.disconnect();
+});
+
+test("suppression never forwards microphone content and stops on end or disconnect", (t) => {
+  t.mock.timers.enable({ apis: ["setInterval"] });
+  for (const end of ["end_call", "disconnect"]) {
+    const { inner, transport } = activeTransport();
+    transport.setInputSuppressed(true);
+    transport.sendBinary(pcm16Frame(25_000));
+    assert.ok(new Uint8Array(inner.sentBinary[0]!).every((sample) => sample === 0));
+    if (end === "end_call") transport.sendJSON({ type: "end_call" });
+    else transport.disconnect();
+    const count = inner.sentBinary.length;
+    t.mock.timers.tick(2000);
+    assert.equal(inner.sentBinary.length, count);
+  }
+});
+
+test("silence is not sent on a disconnected or inactive transport", (t) => {
+  t.mock.timers.enable({ apis: ["setInterval"] });
+  const inner = new FakeTransport();
+  const transport = new TappedVoiceTransport({ agent: "voice-think-agent" }, inner);
+  transport.setInputSuppressed(true);
+  t.mock.timers.tick(1000);
+  assert.equal(inner.sentBinary.length, 0);
+  transport.sendJSON({ type: "start_call" });
+  inner.connected = false;
+  t.mock.timers.tick(1000);
+  assert.equal(inner.sentBinary.length, 0);
+  transport.disconnect();
+});
+
 test("tapped transport reports silence as near-zero output", async () => {
   const { inner, transport } = activeTransport();
   inner.receive(pcm16Frame(0));

--- a/src/ui/tapped-voice-transport.ts
+++ b/src/ui/tapped-voice-transport.ts
@@ -18,6 +18,8 @@ type ScheduledEnvelope = AudioLevelEnvelope & { startsAt: number; endsAt: number
 const MAX_PENDING_MEASUREMENTS = 32;
 const MAX_OUTPUT_ENVELOPES = 2_048;
 const MAX_MIRRORED_PLAYBACK_MS = 60_000;
+const INPUT_SILENCE_INTERVAL_MS = 100;
+const INPUT_SILENCE_BYTES = 16_000 * 2 * INPUT_SILENCE_INTERVAL_MS / 1000;
 
 export class TappedVoiceTransport implements VoiceTransport {
   #inner: VoiceTransport;
@@ -31,6 +33,9 @@ export class TappedVoiceTransport implements VoiceTransport {
   #outputEnvelopes: ScheduledEnvelope[] = [];
   #outputEnvelopeIndex = 0;
   #outputCursor = 0;
+  #inputSuppressed = false;
+  #inputSilenceTimer: ReturnType<typeof setInterval> | null = null;
+  #inputSilenceFrame = new ArrayBuffer(INPUT_SILENCE_BYTES);
 
   constructor(options: TappedVoiceTransportOptions, inner?: VoiceTransport) {
     this.#inner = inner ?? new WebSocketVoiceTransport(options);
@@ -51,6 +56,7 @@ export class TappedVoiceTransport implements VoiceTransport {
     }
     if (data.type === "end_call") {
       this.#inCall = false;
+      this.setInputSuppressed(false);
       this.#resetOutputMeasurement();
     }
     if (data.type === "interrupt") this.#resetOutputMeasurement();
@@ -58,7 +64,20 @@ export class TappedVoiceTransport implements VoiceTransport {
   }
 
   sendBinary(data: ArrayBuffer): void {
-    this.#inner.sendBinary(data);
+    this.#inner.sendBinary(this.#inputSuppressed ? new ArrayBuffer(data.byteLength) : data);
+  }
+
+  setInputSuppressed(suppressed: boolean): void {
+    this.#inputSuppressed = suppressed;
+    if (!suppressed) {
+      if (this.#inputSilenceTimer !== null) clearInterval(this.#inputSilenceTimer);
+      this.#inputSilenceTimer = null;
+      return;
+    }
+    if (this.#inputSilenceTimer !== null) return;
+    this.#inputSilenceTimer = setInterval(() => {
+      if (this.#inCall && this.#inner.connected) this.#inner.sendBinary(this.#inputSilenceFrame);
+    }, INPUT_SILENCE_INTERVAL_MS);
   }
 
   connect(): void {
@@ -67,6 +86,7 @@ export class TappedVoiceTransport implements VoiceTransport {
 
   disconnect(): void {
     this.#inCall = false;
+    this.setInputSuppressed(false);
     this.#resetOutputMeasurement();
     this.#inner.disconnect();
   }


### PR DESCRIPTION
Fixes #213.

Compared the pinned @cloudflare/voice 0.3.5 client and Cloudflare voice examples. Unlike the stock example, My AX automatically mutes while the assistant responds. VoiceClient mute stops sending all audio. A reproduced 11-second reply gap was followed by microphone packets but no second STT transcript.

Keep the streaming recognition session supplied with silent 16kHz PCM while My AX suppresses real microphone audio. Stop the silence timer on unmute, end_call, or disconnect. Use the actual VoiceClient mute state rather than a parallel boolean.

Proof: original production two-spoken-turn test completed the first reply but timed out on the second transcript. With the candidate bundle, both spoken inputs were recognized and answered through real production STT, agent and TTS; maximum packet gap was 181 ms. Transport, acoustic gate, transcript guard, chime tests and typecheck pass. Production bundle verification pending.

No changes to the underlying voice SDK or speech model.