### PR TITLE
fix: refuse delegate_many tasks that need parent workspace tools

### DIFF
--- a/src/delegate-many.test.ts
+++ b/src/delegate-many.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { AgentToolFailure } from "agents/agent-tools";
-import { delegateRunId, shouldRetryDelegate, taskFingerprint } from "./delegate-serial";
+import { delegateRunId, delegateTaskNeedsParentCapabilities, shouldRetryDelegate, taskFingerprint } from "./delegate-serial";
 
 // delegateManyInputSchema lives in delegate-many.ts (which imports Think and so
 // can't load under plain tsx); the input contract is re-validated indirectly by
@@ -29,4 +29,11 @@ test("only a stopped transient interruption receives one retry", () => {
   assert(error);
   assert.equal(error.retryable, false);
   assert.equal(shouldRetryDelegate(error, 1), false);
+});
+
+test("delegate tasks that need parent workspace or tools are refused before spawn", () => {
+  assert.equal(delegateTaskNeedsParentCapabilities("Summarize the two research notes."), false);
+  assert.equal(delegateTaskNeedsParentCapabilities("Read workspace.read /home/user/research/note.md"), true);
+  assert.equal(delegateTaskNeedsParentCapabilities("Use gh issue create for this bug"), true);
+  assert.equal(delegateTaskNeedsParentCapabilities("Call web_search for SPIFFE docs"), true);
 });

--- a/src/delegate-many.ts
+++ b/src/delegate-many.ts
@@ -9,6 +9,7 @@ import {
   delegateResultSchema,
   delegateRunId,
   runDelegatesSerially,
+  delegateTaskNeedsParentCapabilities,
   shouldRetryDelegate,
   taskFingerprint,
   type DelegateResult,
@@ -99,11 +100,15 @@ export function createDelegateManyTool(parent: DelegateParent) {
     // Runs the tasks SERIALLY (not concurrently): two child inferences hitting
     // the shared per-minute cap at once was the observed 3021 double-failure.
     // On 3021 the remaining task is deferred (backpressure), not retried.
-    description: "Delegate one or two independent read-only analysis tasks (run sequentially to respect shared inference limits). The parent must synthesize the retained child evidence.",
+    description: "Delegate one or two independent read-only analysis tasks (run sequentially). The child has no workspace, machine, page, MCP, browser, or web_search tools and does not share the parent Sandbox. Do not send file, shell, GitHub, or browser work here; do that in the parent. The parent must synthesize child evidence.",
     inputSchema: delegateManyInputSchema,
     outputSchema: delegateManyOutputSchema,
     execute: async (input, context) => {
       const parsed = delegateManyInputSchema.parse(input);
+      const blocked = parsed.tasks.find((row) => delegateTaskNeedsParentCapabilities(row.task));
+      if (blocked) {
+        throw new Error(`delegate_many cannot run parent-only work (workspace, machine, page, MCP, browser, web_search, git/gh). Do that in the parent. Blocked task: ${blocked.label ?? blocked.task.slice(0, 80)}`);
+      }
       const runIds = parsed.tasks.map(({ task }, index) => delegateRunId(parent.name, context.toolCallId, task, index));
       const results = await runDelegatesSerially(parsed.tasks, async (index) => {
         const { task } = parsed.tasks[index];

--- a/src/delegate-serial.ts
+++ b/src/delegate-serial.ts
@@ -177,3 +177,10 @@ export async function runDelegatesSerially(
   }
   return results;
 }
+
+const DELEGATE_FORBIDDEN = /\b(workspace\.|machine\.|page\.|web_search|browser_|mcp_|codemode\.|gh |git )/i;
+
+export function delegateTaskNeedsParentCapabilities(task: string): boolean {
+  return DELEGATE_FORBIDDEN.test(task);
+}
+


### PR DESCRIPTION
Closes #231

Delegated children have no Sandbox, MCP, browser, machine, or web_search. The parent still sent them file/GitHub work in Fork · Auth, and they failed twice.

This PR documents that limit on the tool and refuses those tasks before spawn, with a typed error telling the parent to do the work.

Proof: `npx tsx --test src/delegate-many.test.ts`

Do not merge.