### PR TITLE
fix: bind Cloudflare Web Search so owner sessions can search

### DIFF
--- a/src/web-search.test.ts
+++ b/src/web-search.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 import { Effect } from "effect";
 import { createPublicWebSearchTool, performWebSearch } from "./web-search";
@@ -87,4 +88,9 @@ test("returns safe errors without exposing upstream credentials", async () => {
   assert.equal(toolResult, JSON.stringify(unavailable));
   assert.doesNotMatch(JSON.stringify({ failed, unavailable, toolResult }), new RegExp(secret));
   assert.doesNotMatch(JSON.stringify({ failed, unavailable, toolResult }), /Authorization/);
+});
+
+test("wrangler binds Cloudflare Web Search as WEBSEARCH", () => {
+  const wrangler = readFileSync(new URL("../wrangler.jsonc", import.meta.url), "utf8");
+  assert.match(wrangler, /"web_search"\s*:\s*\{\s*"binding"\s*:\s*"WEBSEARCH"/);
 });

--- a/src/web-search.ts
+++ b/src/web-search.ts
@@ -12,7 +12,7 @@ export type PublicWebSearchToolOptions = {
 export function createPublicWebSearchTool(options: PublicWebSearchToolOptions = {}): ToolDef {
   return {
     name: "web_search",
-    description: "Search the public web through Cloudflare Web Search. Returns a bounded list of public result titles, absolute URLs, and snippets for citation. Discovery only: this tool does not open result pages, execute page content, submit forms, or change state.",
+    description: "Search the public web through Cloudflare Web Search. Returns titles, absolute URLs, and snippets. If the Worker has no WEBSEARCH binding, returns error web_search_unavailable instead of pretending to search. Discovery only.",
     parameters: {
       type: "object",
       additionalProperties: false,

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -76,6 +76,7 @@
   // Workers AI binding. Account-level. The Worker's deployment identity
   // is the principal calling Workers AI — no per-user model key.
   "ai": { "binding": "AI" },
+  "web_search": { "binding": "WEBSEARCH" },
   // Browser Run: hosted headless Chrome sessions for visual tool calls.
   "browser": { "binding": "BROWSER" },
   // Dynamic Worker loader for native Think Agent Skills script execution.


### PR DESCRIPTION
Closes #232

Employee My AX had no WEBSEARCH binding, so web_search returned web_search_unavailable and the agent skipped search.

Adds wrangler web_search → WEBSEARCH and documents the typed error on the tool.

Proof: `npx tsx --test src/web-search.test.ts`

Do not merge.