### PR TITLE
fix: factory implementer was POSTing the wrong Responses URL

### DIFF
--- a/agents/src/model-implementation-program.ts
+++ b/agents/src/model-implementation-program.ts
@@ -20,6 +20,13 @@ export class ImplementationRepository extends Context.Service<ImplementationRepo
   read(path: string): Effect.Effect<string, ImplementationModelError>;
 }>()("my-ax/agents/ImplementationRepository") {}
 
+export function implementationResponsesUrl(gatewayUrl: string): string {
+  const base = gatewayUrl.replace(/\/+$/, "");
+  if (/\/v1$/.test(base)) return `${base}/responses`;
+  if (/\/openai$/.test(base)) return `${base}/v1/responses`;
+  return `${base}/v1/responses`;
+}
+
 export function implementationModelLayer(env: AgentsEnv, modelId: string, repository: { paths: string[]; read(path: string): Promise<string> }) {
   return Layer.mergeAll(
     Layer.succeed(ImplementationRepository, {
@@ -34,7 +41,7 @@ export function implementationModelLayer(env: AgentsEnv, modelId: string, reposi
         const authHeader = env.LLM_GATEWAY_AUTH_HEADER?.trim() || "authorization";
         return yield* Effect.tryPromise({
           try: async (signal) => {
-            const response = await fetch(`${base}/responses`, {
+            const response = await fetch(implementationResponsesUrl(base), {
               method: "POST", signal,
               headers: { "content-type": "application/json", [authHeader]: authHeader.toLowerCase() === "authorization" ? `Bearer ${token}` : token, "x-requested-with": "xmlhttprequest" },
               body: JSON.stringify({ model: modelId, input: prompt }),

--- a/agents/src/model-implementation.test.ts
+++ b/agents/src/model-implementation.test.ts
@@ -81,7 +81,9 @@ test("chat smoke validation decodes escaped newlines before comparing source", (
 test("the implementation model selects context and returns bounded source with tests", async () => {
   const originalFetch = globalThis.fetch;
   const prompts: string[] = [];
-  globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+  const urls: string[] = [];
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    urls.push(String(input));
     const request = JSON.parse(String(init?.body || "{}")) as { input?: string };
     prompts.push(request.input || "");
     const text = prompts.length === 1
@@ -109,6 +111,7 @@ test("the implementation model selects context and returns bounded source with t
     }));
     assert.deepEqual(files.map((file) => file.path), ["src/ui/message.ts", "src/ui/message.test.ts"]);
     assert.equal(prompts.length, 2);
+    assert.equal(urls[0], "https://gateway.example/openai/v1/responses");
     assert.doesNotMatch(prompts[1]!, /\.github\/workflows\/deploy\.yml/);
   } finally {
     globalThis.fetch = originalFetch;


### PR DESCRIPTION
The factory implementation model posted `{LLM_GATEWAY_URL}/responses`. Employee gateway is `https://opencode.cloudflare.dev/openai`, so that hit `/openai/responses` and returned **404**. Issues then sat on `implementation model failed with 404` / needs-human.

This posts `/openai/v1/responses`, matching the OpenAI Responses protocol the rest of My AX uses.

Proof: `npx tsx --test agents/src/model-implementation.test.ts`

Does not merge. After CI, this still needs an **agents worker deploy** before live issues stop 404ing.