### PR TITLE
fix: do not close issues onto a dead or parent PR

### DIFF
--- a/agents/src/sweep.test.ts
+++ b/agents/src/sweep.test.ts
@@ -96,11 +96,18 @@ test("needs-human issues remain open without repeat comments or retries", () => 
   assert.deepEqual(actions, []);
 });
 
-test("a real linked PR receives the work and closes the issue", () => {
+test("a real open product PR receives the work and closes the issue", () => {
   const actions = planSweep([
-    { number: 155, title: "bug: sessions", body: "repro", author: "o", state: "open", comments: [], linkedPr: { number: 169, files: ["src/session-title.ts", "src/session-title.test.ts"] } },
+    { number: 155, title: "bug: sessions", body: "repro", author: "o", state: "open", comments: [], hasOpenPr: true, openPr: { number: 169, files: ["src/session-title.ts", "src/session-title.test.ts"] } },
   ]);
   assert.deepEqual(actions, [{ action: "close-issue-to-pr", number: 155, prNumber: 169 }]);
+});
+
+test("a closed or parent-only linked PR does not close the issue", () => {
+  const actions = planSweep([
+    { number: 231, title: "bug: delegate", body: "repro", author: "o", state: "open", comments: [], labels: ["triage:draft"], linkedPr: { number: 235, files: ["src/delegate-many.ts"] } },
+  ]);
+  assert.deepEqual(actions, [{ action: "queue", number: 231 }]);
 });
 
 test("a boarded issue without draft opt-in stays open", () => {

--- a/agents/src/sweep.ts
+++ b/agents/src/sweep.ts
@@ -97,8 +97,10 @@ export function planSweep(issues: SweepIssue[], now = Date.now()): SweepAction[]
   const closing = new Set(actions.filter((row) => row.action === "close-duplicate").map((row) => row.number));
   for (const issue of open) {
     if (closing.has(issue.number)) continue;
-    if (issue.linkedPr && !isFactoryOnlyChange(issue.linkedPr.files)) {
-      actions.push({ action: "close-issue-to-pr", number: issue.number, prNumber: issue.linkedPr.number });
+    const liveProductPr = (issue.openPr && !isFactoryOnlyChange(issue.openPr.files) ? issue.openPr : null)
+      ?? (issue.linkedPr && issue.hasOpenPr && !isFactoryOnlyChange(issue.linkedPr.files) ? issue.linkedPr : null);
+    if (liveProductPr) {
+      actions.push({ action: "close-issue-to-pr", number: issue.number, prNumber: liveProductPr.number });
       continue;
     }
     if (issue.openPr && isFactoryOnlyChange(issue.openPr.files)) {


### PR DESCRIPTION
Factory sweep closed #231 onto closed parent PR #235. Sweep now only closes an issue onto a currently open product PR. Proof: npx tsx --test agents/src/sweep.test.ts. Do not merge from the factory.