### PR TITLE
fix: do not treat a story about closing an issue as Closes

### DIFF
--- a/agents/src/ports.ts
+++ b/agents/src/ports.ts
@@ -4,6 +4,13 @@ import type { GithubPort, TerrariumPort } from "./orchestrate";
 import type { AgentsEnv } from "./workflows";
 import { createImplementationGrant } from "./implementation-submission";
 
+export function prClosesIssue(issueNumber: number, title: string, body: string, headRef: string): boolean {
+  if (headRef.includes(`issue-${issueNumber}`)) return true;
+  const escaped = String(issueNumber).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const closes = new RegExp(`(?:^|\\n)\\s*(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\s+#${escaped}\\b`, "i");
+  return closes.test(`${title}\n${body}`);
+}
+
 export function liveGithubPort(env: AgentsEnv & { GITHUB_TOKEN?: string; GITHUB_REPO?: string }): GithubPort {
   const token = env.GITHUB_TOKEN?.trim();
   const repo = env.GITHUB_REPO?.trim() || "acoyfellow/my-ax";
@@ -121,11 +128,9 @@ export function liveGithubPort(env: AgentsEnv & { GITHUB_TOKEN?: string; GITHUB_
     async findOpenPrForIssue(issueNumber) {
       assertNoMergeAction("findOpenPrForIssue");
       const json = await gh("/pulls?state=open&per_page=100&sort=updated&direction=desc");
-      const escaped = String(issueNumber).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      const closes = new RegExp(`\\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\s+#${escaped}\\b`, "i");
       const row = (Array.isArray(json) ? json : []).find((candidate) => {
         const pr = candidate as { number?: number; title?: string; body?: string; head?: { ref?: string } };
-        return closes.test(String(pr.body || "")) || String(pr.head?.ref || "").includes(`issue-${issueNumber}`);
+        return prClosesIssue(issueNumber, String(pr.title || ""), String(pr.body || ""), String(pr.head?.ref || ""));
       }) as { number?: number } | undefined;
       const number = Number(row?.number);
       if (!Number.isInteger(number) || number <= 0) return null;

--- a/agents/src/pr-closes-issue.test.ts
+++ b/agents/src/pr-closes-issue.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { prClosesIssue } from "./ports";
+
+test("a PR body that only narrates a past close does not own the issue", () => {
+  const body = "Factory sweep closed #231 onto #235 after that PR was already closed.";
+  assert.equal(prClosesIssue(231, "fix: do not close issues onto a dead PR", body, "bot/fix-factory-close-to-pr"), false);
+});
+
+test("a real Closes keyword on its own line still owns the issue", () => {
+  assert.equal(prClosesIssue(231, "fix: refuse parent-only delegate tasks", "Closes #231\n\nThe child has no workspace.", "bot/issue-231"), true);
+});
+
+test("the issue branch name still owns the issue", () => {
+  assert.equal(prClosesIssue(231, "wip", "no keyword", "bot/issue-231"), true);
+});

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "test:dead-session-scan": "tsx --test src/dead-session-scan.test.ts",
     "test:memory-block": "tsx --test src/memory-block.test.ts",
     "test:notify": "tsx --test src/notify.test.ts",
-    "test:lifecycle-agents": "tsx --test agents/src/implementation-submission.test.ts agents/src/implementation-worker.test.ts agents/src/model-implementation.test.ts agents/src/implementation-hook.test.ts agents/src/audit-effect.test.ts agents/src/triage-effect.test.ts agents/src/policy.test.ts agents/src/harness.test.ts agents/src/github-hmac.test.ts agents/src/sweep.test.ts agents/src/review.test.ts agents/src/preview-check.test.ts agents/src/docs-drift.test.ts",
+    "test:lifecycle-agents": "tsx --test agents/src/implementation-submission.test.ts agents/src/implementation-worker.test.ts agents/src/model-implementation.test.ts agents/src/implementation-hook.test.ts agents/src/audit-effect.test.ts agents/src/triage-effect.test.ts agents/src/policy.test.ts agents/src/harness.test.ts agents/src/github-hmac.test.ts agents/src/sweep.test.ts agents/src/review.test.ts agents/src/preview-check.test.ts agents/src/docs-drift.test.ts agents/src/pr-closes-issue.test.ts",
     "test:push-decision-actions": "tsx --test src/push-decision-actions.test.ts",
     "test:sw-decision-click": "tsx --test src/sw-decision-click.test.ts",
     "test:push-progress-tag": "tsx --test src/push-progress-tag.test.ts",


### PR DESCRIPTION
Sweep attached #231 to #238 because the PR body said "closed #231" in a sentence. Matching now requires the GitHub keyword at the start of a line, or the bot/issue-N branch. Proof: npx tsx --test agents/src/pr-closes-issue.test.ts