### PR TITLE
fix: scheduled jobs Illegal invocation on inject

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -246,6 +246,7 @@ export class MyAgent extends Think<Env> {
   }
 
   async injectUserMessage(body: { content?: string; clientMsgId?: string; attachments?: Attachment[] }) {
+    await this.onStart();
     const identity = this.getConfig<MyAgentConfig>()?.identity;
     if (!identity) throw new Error("session identity not seeded");
     const content = (body.content ?? "").trim();

--- a/src/inject-onstart.test.ts
+++ b/src/inject-onstart.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+
+const agent = readFileSync(new URL("./agent.ts", import.meta.url), "utf8");
+
+test("RPC inject starts Think before submit so scheduled jobs do not Illegal invocation", () => {
+  const start = agent.indexOf("async injectUserMessage");
+  const end = agent.indexOf("async sessionTurnState");
+  assert.ok(start >= 0 && end > start);
+  const slice = agent.slice(start, end);
+  assert.match(slice, /await this\.onStart\(\)/);
+  assert.match(slice, /this\.runTurn/);
+});


### PR DESCRIPTION
Job RPC inject skipped onStart, so Think Session was uninitialized. Live issue-sweep session 012ad8d6 died with Illegal invocation. HTTP inject already called onStart; RPC now matches. Proof: npx tsx --test src/inject-onstart.test.ts