### PR TITLE
fix: bind getTools this for scheduled job turns

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -517,10 +517,11 @@ export class MyAgent extends Think<Env> {
   }
 
   getTools() {
+    const agent = this;
     return {
-      ...createThinkTools(() => this.buildToolContext()),
-      ...createMyAxBrowserTools(this.env, () => this.identity(), () => this.name),
-      delegate_many: createDelegateManyTool(this),
+      ...createThinkTools(() => agent.buildToolContext()),
+      ...createMyAxBrowserTools(agent.env, () => agent.identity(), () => agent.name),
+      delegate_many: createDelegateManyTool(agent),
     };
   }
 

--- a/src/inject-onstart.test.ts
+++ b/src/inject-onstart.test.ts
@@ -12,3 +12,11 @@ test("RPC inject starts Think before submit so scheduled jobs do not Illegal inv
   assert.match(slice, /await this\.onStart\(\)/);
   assert.match(slice, /this\.runTurn/);
 });
+
+test("getTools closes over the agent instance instead of relying on call-site this", () => {
+  const start = agent.indexOf("getTools()");
+  const end = agent.indexOf("override async onBeforeSubAgent");
+  const slice = agent.slice(start, end);
+  assert.match(slice, /const agent = this/);
+  assert.match(slice, /createThinkTools\(\(\) => agent\.buildToolContext\(\)\)/);
+});


### PR DESCRIPTION
onStart on inject was not enough: live job session c3b64641 still Illegal invocation on 459a572. getTools now closes over the agent instance. Proof: npx tsx --test src/inject-onstart.test.ts