### PR TITLE
fix: bind fetch this for gateway model turns

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -517,10 +517,11 @@ export class MyAgent extends Think<Env> {
   }
 
   getTools() {
+    const agent = this;
     return {
-      ...createThinkTools(() => this.buildToolContext()),
-      ...createMyAxBrowserTools(this.env, () => this.identity(), () => this.name),
-      delegate_many: createDelegateManyTool(this),
+      ...createThinkTools(() => agent.buildToolContext()),
+      ...createMyAxBrowserTools(agent.env, () => agent.identity(), () => agent.name),
+      delegate_many: createDelegateManyTool(agent),
     };
   }
 

--- a/src/gateway-retry-fetch.test.ts
+++ b/src/gateway-retry-fetch.test.ts
@@ -25,6 +25,18 @@ test("nextBackoffMs grows exponentially and is capped", () => {
   assert.ok(nextBackoffMs(10, 500, 8000, r) === 8000, "capped");
 });
 
+test("calls fetch with globalThis as this so Workers do not Illegal invocation", async () => {
+  let seen: unknown;
+  function methodFetch(this: unknown, _input: RequestInfo | URL, _init?: RequestInit) {
+    seen = this;
+    return Promise.resolve(res(200));
+  }
+  const rf = createRetryFetch({ fetch: methodFetch as typeof fetch, maxAttempts: 1 });
+  const out = await rf("https://gw/x");
+  assert.equal(out.status, 200);
+  assert.equal(seen, globalThis);
+});
+
 test("retries a 429 then returns the eventual success", async () => {
   let calls = 0;
   const slept: number[] = [];

--- a/src/gateway-retry.ts
+++ b/src/gateway-retry.ts
@@ -41,7 +41,7 @@ export function retryFetchEffect(deps: RetryFetchDeps, input: RequestInfo | URL,
     let waited = 0;
     let last: Response | null = null;
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      const response = yield* Effect.promise(() => deps.fetch(input as Parameters<typeof fetch>[0], init));
+      const response = yield* Effect.promise(() => deps.fetch.call(globalThis, input as Parameters<typeof fetch>[0], init));
       if (!isRateLimitResponse(response)) return response;
       last = response;
       if (attempt === maxAttempts - 1) break;

--- a/src/inject-onstart.test.ts
+++ b/src/inject-onstart.test.ts
@@ -12,3 +12,11 @@ test("RPC inject starts Think before submit so scheduled jobs do not Illegal inv
   assert.match(slice, /await this\.onStart\(\)/);
   assert.match(slice, /this\.runTurn/);
 });
+
+test("getTools closes over the agent instance instead of relying on call-site this", () => {
+  const start = agent.indexOf("getTools()");
+  const end = agent.indexOf("override async onBeforeSubAgent");
+  const slice = agent.slice(start, end);
+  assert.match(slice, /const agent = this/);
+  assert.match(slice, /createThinkTools\(\(\) => agent\.buildToolContext\(\)\)/);
+});

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -93,7 +93,7 @@ export function resolveMyAxModel(env: Env, requestedModel?: string) {
       // Transparently retry transient gateway rate limits (3021 / 429) with
       // bounded backoff so a per-minute cap blip self-heals instead of failing
       // the turn. See src/gateway-retry-fetch.ts (#6).
-      fetch: createRetryFetch({ fetch: globalThis.fetch }),
+      fetch: createRetryFetch({ fetch: globalThis.fetch.bind(globalThis) }),
     })(meta.upstreamId ?? modelId);
   } else {
     const gateway = modelGatewayConfig(env, meta);
@@ -102,7 +102,7 @@ export function resolveMyAxModel(env: Env, requestedModel?: string) {
       baseURL: gateway.baseURL,
       apiKey: meta.gateway === "special" ? env.LLM_SPECIAL_GATEWAY_TOKEN! : "",
       headers: gateway.headers,
-      fetch: createRetryFetch({ fetch: globalThis.fetch }),
+      fetch: createRetryFetch({ fetch: globalThis.fetch.bind(globalThis) }),
     }).responses(meta.upstreamId ?? modelId);
   }
 


### PR DESCRIPTION
Live job session e3c941c3 still Illegal invocation on 43c7d73 after onStart + getTools binds. Cause: createRetryFetch passed unbound globalThis.fetch. Proof: npx tsx --test src/gateway-retry-fetch.test.ts src/llm.test.ts