### PR TITLE
docs: factory is one same-session heartbeat

### DIFF
--- a/docs/factory.md
+++ b/docs/factory.md
@@ -1,47 +1,63 @@
 # Factory (a recurring job, not a product)
 
-There is no Factory tab and no factory verb. A factory is a **recurring job** that watches GitHub issues and opens **one conversation per issue**.
+There is no Factory tab and no factory verb. A factory is **one durable My AX conversation** plus a **recurring job** that pings that same thread on a short cadence. It is not a new session every run.
 
 Checkpoint to eject to: git SHA `4f0be045daee26d6ba185327c7292d738fba7617` (sidecar agents Worker with keyword-safe sweep). The scheduled sidecar sweep is **off**. Do not turn that cron back on unless you eject.
+
+## Shape (like a terraloop)
+
+| Piece | What it is |
+| --- | --- |
+| Cockpit | One session. Title it `factory`. `thread_mode=same_session`. |
+| Heartbeat | Recurring job, **60s**, `max_runs` unset. Each ping is "keep going", not a new chat. |
+| Fan-out | When an open issue has no conversation titled `Issue #<n>: …`, open that chat (cap 3 new per ping). |
+| Stop | Delete or pause the job. Issue sessions stay. |
+
+A `new_session_per_run` job with `max_runs: 1` is **not** a factory. It dies after one turn and has no heartbeat.
 
 ## What you already have
 
 - Settings → Recurring jobs
-- Thread mode **New thread each run** (`new_session_per_run`)
+- Thread mode **Same thread** (`same_session`)
 - Sandbox `gh` for the repo this deploy uses
-- Push when a job needs you
+- `notify_owner` when blocked
 
 ## One-time setup
 
-1. Settings → Recurring jobs → add a job.
-2. Name: `issue sweep`
-3. Cadence: 15 minutes (or slower).
-4. Thread: **New thread each run** for the sweep itself, **or** keep one sweep session and let the prompt open chats — if the job can only mint *its* run session, use that session as the sweep cockpit and start issue threads from there with the same title rule.
-5. Prompt (copy):
+1. Open (or keep) one chat named `factory`.
+2. Settings → Recurring jobs → add a job **on that session**.
+3. Name: `factory`
+4. Cadence: **60 seconds** (minimum the product allows).
+5. Thread: **Same thread**.
+6. Max runs: empty (unlimited until you pause/delete).
+7. Prompt (copy):
 
 ```
-You are the issue sweep. Do not comment on GitHub issues except by opening or updating a pull request.
+You are the factory cockpit. Stay in this session. Do not create, pause, or delete recurring jobs.
 
-List open issues on this repo with label triage:draft that are not already a conversation titled exactly:
-Issue #<number>: <title>
+Each ping: work one cycle, then stop until the next ping.
 
-Cap: 3 new conversations per run.
-
-For each new issue, start a conversation with that title. First message is the contract:
-- Goal: smallest product fix plus a focused test, or kill with proof
-- Gate: a PR on bot/issue-<n> with a human-readable review, or this session contains killed: and evidence
-- Proof: the test or command that would fail before the fix
-- Never merge. Never approve. Ping the owner with notify_owner if blocked.
-
-Skip issues that already have that session title.
+1. Heartbeat: notify_owner only if you are blocked or a PR needs a human. Do not ping every cycle.
+2. List open issues on this repo (skip needs-human / already killed with evidence). Prefer actionable product bugs over meta tickets.
+3. Fan-out: for each issue that does not already have a conversation titled exactly
+   Issue #<number>: <title>
+   open that conversation. Cap: 3 new per ping.
+4. First message in each Issue #<n>: session is the contract:
+   - Goal: smallest product fix plus a focused test, or kill with proof
+   - Gate: a PR on bot/issue-<n> with a human-readable review, or this session contains killed: and evidence
+   - Proof: the test or command that would fail before the fix
+   - Never merge. Never approve. Ping the owner with notify_owner if blocked.
+5. If Issue #<n>: sessions already exist, inject a one-line continue: "heartbeat: still open / blocked / PR ready" — do not restart the contract.
+6. Do not comment on GitHub issues except by opening or updating a pull request.
+7. Never merge. Never approve.
 ```
 
 ## Title rule
 
 `Issue #231: delegated agent cannot see parent workspace`
 
-The sweep skips titles that already exist. GitHub is the forge (branches, PRs). My AX is the control room.
+The cockpit skips titles that already exist. GitHub is the forge (branches, PRs). My AX is the control room.
 
 ## Stop
 
-Delete the recurring job. Issue sessions stay as normal chats. Sidecar factory stays off unless you eject to `4f0be04` and restore cron yourself.
+Pause or delete the `factory` job. Issue sessions stay as normal chats. Sidecar factory stays off unless you eject to `4f0be04` and restore cron yourself.

--- a/docs/factory.md
+++ b/docs/factory.md
@@ -9,11 +9,22 @@ Checkpoint to eject to: git SHA `4f0be045daee26d6ba185327c7292d738fba7617` (side
 | Piece | What it is |
 | --- | --- |
 | Cockpit | One session. Title it `factory`. `thread_mode=same_session`. |
-| Heartbeat | Recurring job, **60s**, `max_runs` unset. Each ping is "keep going", not a new chat. |
+| Heartbeat | Recurring job. Cadence is the owner's choice. `max_runs` unset. Each ping is "keep going", not a new chat. |
 | Fan-out | When an open issue has no conversation titled `Issue #<n>: …`, open that chat (cap 3 new per ping). |
+| Place | **My AX Workspace (Sandbox) only.** Never My Machine. Never cmux. Never the live page. |
 | Stop | Delete or pause the job. Issue sessions stay. |
 
 A `new_session_per_run` job with `max_runs: 1` is **not** a factory. It dies after one turn and has no heartbeat.
+
+## Hard place rule
+
+The factory does **not** use the owner's laptop.
+
+Allowed: Sandbox `gh`, Sandbox files, My AX session tools (`listSessions`, `inject`, `notify_owner`).
+
+Forbidden: `machine.*`, cmux, page verbs, steering another Pi on the desk, screenshots of local terminals.
+
+If a tool would run on My Machine, skip it and `notify_owner` instead.
 
 ## What you already have
 
@@ -27,7 +38,7 @@ A `new_session_per_run` job with `max_runs: 1` is **not** a factory. It dies aft
 1. Open (or keep) one chat named `factory`.
 2. Settings → Recurring jobs → add a job **on that session**.
 3. Name: `factory`
-4. Cadence: **60 seconds** (minimum the product allows).
+4. Cadence: pick a human interval (minutes, not a 60s storm).
 5. Thread: **Same thread**.
 6. Max runs: empty (unlimited until you pause/delete).
 7. Prompt (copy):
@@ -35,10 +46,12 @@ A `new_session_per_run` job with `max_runs: 1` is **not** a factory. It dies aft
 ```
 You are the factory cockpit. Stay in this session. Do not create, pause, or delete recurring jobs.
 
+Place: My AX Workspace (Sandbox) only. Never My Machine. Never cmux. Never page tools. Never steer a local Pi.
+
 Each ping: work one cycle, then stop until the next ping.
 
 1. Heartbeat: notify_owner only if you are blocked or a PR needs a human. Do not ping every cycle.
-2. List open issues on this repo (skip needs-human / already killed with evidence). Prefer actionable product bugs over meta tickets.
+2. List open issues with Sandbox gh on this repo (skip needs-human / already killed with evidence). Prefer actionable product bugs over meta tickets.
 3. Fan-out: for each issue that does not already have a conversation titled exactly
    Issue #<number>: <title>
    open that conversation. Cap: 3 new per ping.
@@ -47,6 +60,7 @@ Each ping: work one cycle, then stop until the next ping.
    - Gate: a PR on bot/issue-<n> with a human-readable review, or this session contains killed: and evidence
    - Proof: the test or command that would fail before the fix
    - Never merge. Never approve. Ping the owner with notify_owner if blocked.
+   - That issue session also stays in Sandbox. It must not use My Machine.
 5. If Issue #<n>: sessions already exist, inject a one-line continue: "heartbeat: still open / blocked / PR ready" — do not restart the contract.
 6. Do not comment on GitHub issues except by opening or updating a pull request.
 7. Never merge. Never approve.
@@ -56,7 +70,7 @@ Each ping: work one cycle, then stop until the next ping.
 
 `Issue #231: delegated agent cannot see parent workspace`
 
-The cockpit skips titles that already exist. GitHub is the forge (branches, PRs). My AX is the control room.
+The cockpit skips titles that already exist. GitHub is the forge (branches, PRs). My AX Sandbox is the control room. The laptop is out of bounds.
 
 ## Stop
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -517,10 +517,11 @@ export class MyAgent extends Think<Env> {
   }
 
   getTools() {
+    const agent = this;
     return {
-      ...createThinkTools(() => this.buildToolContext()),
-      ...createMyAxBrowserTools(this.env, () => this.identity(), () => this.name),
-      delegate_many: createDelegateManyTool(this),
+      ...createThinkTools(() => agent.buildToolContext()),
+      ...createMyAxBrowserTools(agent.env, () => agent.identity(), () => agent.name),
+      delegate_many: createDelegateManyTool(agent),
     };
   }
 

--- a/src/gateway-retry-fetch.test.ts
+++ b/src/gateway-retry-fetch.test.ts
@@ -25,6 +25,18 @@ test("nextBackoffMs grows exponentially and is capped", () => {
   assert.ok(nextBackoffMs(10, 500, 8000, r) === 8000, "capped");
 });
 
+test("calls fetch with globalThis as this so Workers do not Illegal invocation", async () => {
+  let seen: unknown;
+  function methodFetch(this: unknown, _input: RequestInfo | URL, _init?: RequestInit) {
+    seen = this;
+    return Promise.resolve(res(200));
+  }
+  const rf = createRetryFetch({ fetch: methodFetch as typeof fetch, maxAttempts: 1 });
+  const out = await rf("https://gw/x");
+  assert.equal(out.status, 200);
+  assert.equal(seen, globalThis);
+});
+
 test("retries a 429 then returns the eventual success", async () => {
   let calls = 0;
   const slept: number[] = [];

--- a/src/gateway-retry.ts
+++ b/src/gateway-retry.ts
@@ -41,7 +41,7 @@ export function retryFetchEffect(deps: RetryFetchDeps, input: RequestInfo | URL,
     let waited = 0;
     let last: Response | null = null;
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      const response = yield* Effect.promise(() => deps.fetch(input as Parameters<typeof fetch>[0], init));
+      const response = yield* Effect.promise(() => deps.fetch.call(globalThis, input as Parameters<typeof fetch>[0], init));
       if (!isRateLimitResponse(response)) return response;
       last = response;
       if (attempt === maxAttempts - 1) break;

--- a/src/inject-onstart.test.ts
+++ b/src/inject-onstart.test.ts
@@ -12,3 +12,11 @@ test("RPC inject starts Think before submit so scheduled jobs do not Illegal inv
   assert.match(slice, /await this\.onStart\(\)/);
   assert.match(slice, /this\.runTurn/);
 });
+
+test("getTools closes over the agent instance instead of relying on call-site this", () => {
+  const start = agent.indexOf("getTools()");
+  const end = agent.indexOf("override async onBeforeSubAgent");
+  const slice = agent.slice(start, end);
+  assert.match(slice, /const agent = this/);
+  assert.match(slice, /createThinkTools\(\(\) => agent\.buildToolContext\(\)\)/);
+});

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -93,7 +93,7 @@ export function resolveMyAxModel(env: Env, requestedModel?: string) {
       // Transparently retry transient gateway rate limits (3021 / 429) with
       // bounded backoff so a per-minute cap blip self-heals instead of failing
       // the turn. See src/gateway-retry-fetch.ts (#6).
-      fetch: createRetryFetch({ fetch: globalThis.fetch }),
+      fetch: createRetryFetch({ fetch: globalThis.fetch.bind(globalThis) }),
     })(meta.upstreamId ?? modelId);
   } else {
     const gateway = modelGatewayConfig(env, meta);
@@ -102,7 +102,7 @@ export function resolveMyAxModel(env: Env, requestedModel?: string) {
       baseURL: gateway.baseURL,
       apiKey: meta.gateway === "special" ? env.LLM_SPECIAL_GATEWAY_TOKEN! : "",
       headers: gateway.headers,
-      fetch: createRetryFetch({ fetch: globalThis.fetch }),
+      fetch: createRetryFetch({ fetch: globalThis.fetch.bind(globalThis) }),
     }).responses(meta.upstreamId ?? modelId);
   }
 


### PR DESCRIPTION
Factory died because it was a one-shot new_session_per_run job. Docs now match terraloop: one cockpit thread, 60s same_session pings, fan-out Issue #<n>: sessions, unlimited until paused. Live job cdc85c19 on session ca055f09.