### PR TITLE
fix: scheduled job injects are Job, not You

### DIFF
--- a/src/jobs-prompt.ts
+++ b/src/jobs-prompt.ts
@@ -1,0 +1,9 @@
+export const SCHEDULED_JOB_RUN_PREFIX = "You are executing one scheduled run of an existing recurring job. Do not create, update, resume, pause, delete, or schedule recurring jobs from this run unless the owner explicitly asked this run to modify job configuration. Do the requested check/work once, leave truthful receipts/notifications required by the prompt, then stop.";
+
+export function scheduledJobRunPrompt(prompt: string): string {
+  return `${SCHEDULED_JOB_RUN_PREFIX}\n\n${prompt}`;
+}
+
+export function isScheduledJobRunMessage(content: string): boolean {
+  return content.startsWith(SCHEDULED_JOB_RUN_PREFIX);
+}

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -135,11 +135,7 @@ export function validateJobInput(input: Partial<JobInput>): ValidationError | Jo
  * Ownership is the caller's responsibility — REST routes verify the
  * owner_email match before calling.
  */
-export const SCHEDULED_JOB_RUN_PREFIX = "You are executing one scheduled run of an existing recurring job. Do not create, update, resume, pause, delete, or schedule recurring jobs from this run unless the owner explicitly asked this run to modify job configuration. Do the requested check/work once, leave truthful receipts/notifications required by the prompt, then stop.";
-
-export function scheduledJobRunPrompt(prompt: string): string {
-  return `${SCHEDULED_JOB_RUN_PREFIX}\n\n${prompt}`;
-}
+export { SCHEDULED_JOB_RUN_PREFIX, scheduledJobRunPrompt } from "./jobs-prompt";
 
 export async function runJobNow(env: Env, row: JobRow, now: Date = new Date()): Promise<{ next_run_at: string | null; ok: boolean; error?: string; target_session_id: string; thread_mode: RecurringJobThreadMode; max_runs: number | null; run_count: number; status: JobStatus; remaining_runs: number | null }> {
   const claim = await claimRecurringJobRun(env, row.id, row.owner_email);

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -6,6 +6,7 @@
 
 import type { Env } from "./types";
 import { completeRecurringJobRun } from "./recurring-job-run";
+import { scheduledJobRunPrompt } from "./jobs-prompt";
 import { MAX_GENERATED_SESSION_TITLE_CODE_POINTS, truncateUnicodeCodePoints } from "./unicode-text";
 
 async function sessionAgent(env: Env, ownerEmail: string, sessionId: string) {

--- a/src/session-title.test.ts
+++ b/src/session-title.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { deriveSessionTitle, isScheduledJobRunMessage } from "./session-title";
-import { SCHEDULED_JOB_RUN_PREFIX } from "./jobs";
+import { SCHEDULED_JOB_RUN_PREFIX } from "./jobs-prompt";
 
 test("scheduled job injects are not owner messages", () => {
   assert.equal(isScheduledJobRunMessage(`${SCHEDULED_JOB_RUN_PREFIX}\n\nCheck the status.`), true);

--- a/src/session-title.test.ts
+++ b/src/session-title.test.ts
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { deriveSessionTitle } from "./session-title";
+import { deriveSessionTitle, isScheduledJobRunMessage } from "./session-title";
 import { SCHEDULED_JOB_RUN_PREFIX } from "./jobs";
+
+test("scheduled job injects are not owner messages", () => {
+  assert.equal(isScheduledJobRunMessage(`${SCHEDULED_JOB_RUN_PREFIX}\n\nCheck the status.`), true);
+  assert.equal(isScheduledJobRunMessage("Check the status."), false);
+});
 
 test("scheduled job guard prefix is stripped from session and notification titles", () => {
   const title = deriveSessionTitle(`${SCHEDULED_JOB_RUN_PREFIX}\n\nCheck the status.`);

--- a/src/session-title.ts
+++ b/src/session-title.ts
@@ -1,9 +1,13 @@
 import { SCHEDULED_JOB_RUN_PREFIX } from "./jobs";
 import { MAX_GENERATED_SESSION_TITLE_CODE_POINTS, truncateUnicodeCodePoints } from "./unicode-text";
 
+export function isScheduledJobRunMessage(content: string): boolean {
+  return content.startsWith(SCHEDULED_JOB_RUN_PREFIX);
+}
+
 export function deriveSessionTitle(content: string): string {
   const withoutCodeBlocks = content.replace(/```[\s\S]*?```/g, "");
-  const withoutScheduledJobFrame = withoutCodeBlocks.startsWith(SCHEDULED_JOB_RUN_PREFIX)
+  const withoutScheduledJobFrame = isScheduledJobRunMessage(withoutCodeBlocks)
     ? withoutCodeBlocks.slice(SCHEDULED_JOB_RUN_PREFIX.length)
     : withoutCodeBlocks;
   const cleaned = withoutScheduledJobFrame.replace(/\s+/g, " ").trim();

--- a/src/session-title.ts
+++ b/src/session-title.ts
@@ -1,9 +1,7 @@
-import { SCHEDULED_JOB_RUN_PREFIX } from "./jobs";
+import { isScheduledJobRunMessage, SCHEDULED_JOB_RUN_PREFIX } from "./jobs-prompt";
 import { MAX_GENERATED_SESSION_TITLE_CODE_POINTS, truncateUnicodeCodePoints } from "./unicode-text";
 
-export function isScheduledJobRunMessage(content: string): boolean {
-  return content.startsWith(SCHEDULED_JOB_RUN_PREFIX);
-}
+export { isScheduledJobRunMessage };
 
 export function deriveSessionTitle(content: string): string {
   const withoutCodeBlocks = content.replace(/```[\s\S]*?```/g, "");

--- a/src/ui/Chat.svelte
+++ b/src/ui/Chat.svelte
@@ -31,6 +31,7 @@
   import { activeTurnIsRestorable, pendingFirstBelongsHere } from "./session-latch";
   import { captureConfig, frameDimensions, frameFilename } from "./webcam-frame";
   import { sessionTurnLocksComposer, type SessionTurnState } from "../session-turn";
+  import { isScheduledJobRunMessage } from "../session-title";
   import { decideComposerKey, isMobileComposer } from "./composer-keys";
   import {
     agentStatusFor,
@@ -2627,7 +2628,7 @@
             {#if m.role !== "tool"}
               <header class="msg-head">
                 <span class="msg-head__role">
-                  {m.role === "user" ? "You" : m.role === "assistant" ? "Agent" : m.role === "error" ? "Error" : "System"}
+                  {m.role === "user" && isScheduledJobRunMessage(m.content) ? "Job" : m.role === "user" ? "You" : m.role === "assistant" ? "Agent" : m.role === "error" ? "Error" : "System"}
                 </span>
                 {#if m.timestamp}
                   {@const d = new Date(m.timestamp)}

--- a/src/ui/Chat.svelte
+++ b/src/ui/Chat.svelte
@@ -31,7 +31,7 @@
   import { activeTurnIsRestorable, pendingFirstBelongsHere } from "./session-latch";
   import { captureConfig, frameDimensions, frameFilename } from "./webcam-frame";
   import { sessionTurnLocksComposer, type SessionTurnState } from "../session-turn";
-  import { isScheduledJobRunMessage } from "../session-title";
+  import { isScheduledJobRunMessage } from "../jobs-prompt";
   import { decideComposerKey, isMobileComposer } from "./composer-keys";
   import {
     agentStatusFor,

--- a/src/ui/chat-composer-smoke.mjs
+++ b/src/ui/chat-composer-smoke.mjs
@@ -17,6 +17,7 @@ function assertNotIncludes(haystack, needle, label) {
   }
 }
 
+assertIncludes(chat, 'm.role === "user" && isScheduledJobRunMessage(m.content) ? "Job"', "scheduled job injects are labeled Job, not You");
 assertIncludes(chat, 'if (composerLocked && wsState.status !== "done") return wsState.status;', "composer collapses completed turns back to Send");
 assertIncludes(chat, 'return "idle";', "composer falls back to Send after completed turns");
 assertIncludes(chat, 'aria-label={wsState.conn === "offline" ? "Offline — tap to retry" : sendStatus === "thinking" || sendStatus === "running" ? "Stop the agent" : "Send message"}', "composer accessible action remains Send/Stop and offers Retry when terminally offline");


### PR DESCRIPTION
Hydration showed the factory heartbeat as a You bubble. That text is injectUserMessage from jobsRun, not the owner. Chat now labels those prefix-matching turns Job. Proof: npx tsx --test src/session-title.test.ts && node src/ui/chat-composer-smoke.mjs